### PR TITLE
FEAT/GASP-1531/stash ferry deposit and improvements

### DIFF
--- a/stash/api/Tracing environment.postman_environment.json
+++ b/stash/api/Tracing environment.postman_environment.json
@@ -22,7 +22,7 @@
 		},
 		{
 			"key": "status",
-			"value": "L1_INITIATED",
+			"value": "PendingOnL1",
 			"type": "default",
 			"enabled": true
 		}

--- a/stash/src/model/Deposit.ts
+++ b/stash/src/model/Deposit.ts
@@ -14,6 +14,7 @@ const depositSchema = new Schema(
     amount: { type: 'string' },
     asset_chainId: { type: 'string' },
     asset_address: { type: 'string' },
+    closedBy: { type: 'string' },
   },
   {
     dataStructure: 'JSON',

--- a/stash/src/scraper/DepositScraper.ts
+++ b/stash/src/scraper/DepositScraper.ts
@@ -36,7 +36,6 @@ export const processFerriedDeposit = async (
     .and('requestId')
     .equals(Number(eventData.deposit.requestId.id))
     .returnFirst()
-  console.log('transactionsToProcess', transactionsToProcess)
   if (transactionsToProcess) {
     transactionsToProcess.status = 'Processed'
     const timestamp = new Date().toISOString()

--- a/stash/src/scraper/DepositScraper.ts
+++ b/stash/src/scraper/DepositScraper.ts
@@ -1,0 +1,51 @@
+import { Block, Event } from './BlockScraper'
+import _ from 'lodash'
+import { depositRepository } from '../repository/TransactionRepository.js'
+import { ApiPromise } from '@polkadot/api'
+import logger from '../util/Logger.js'
+
+export const processFerriedDepositEvents = async (
+  api: ApiPromise,
+  block: Block
+) => {
+  const events = _.chain(block.events)
+    .filter((ev) => filterEvents(ev[1]))
+    .groupBy(([idx, _]) => idx)
+    .map((evs, _) => evs.map(([_, ev]) => ev))
+    .value()
+  if (events.length > 0) {
+    for (const eventGroup of events) {
+      for (const event of eventGroup) {
+        const ferriedDepositData = await processFerriedDeposit(api, event.data)
+        logger.info('Ferried deposit processed', ferriedDepositData)
+      }
+    }
+  }
+}
+
+export const processFerriedDeposit = async (
+  api: ApiPromise,
+  eventData: any
+): Promise<object> => {
+  const transactionsToProcess = await depositRepository
+    .search()
+    .where('chain')
+    .equals(eventData.chain)
+    .and('type')
+    .equals('deposit')
+    .and('requestId')
+    .equals(Number(eventData.deposit.requestId.id))
+    .returnFirst()
+  console.log('transactionsToProcess', transactionsToProcess)
+  if (transactionsToProcess) {
+    transactionsToProcess.status = 'Processed'
+    const timestamp = new Date().toISOString()
+    transactionsToProcess.updated = Date.parse(timestamp)
+    transactionsToProcess.closedBy = 'ferry'
+    return await depositRepository.save(transactionsToProcess)
+  }
+}
+
+const filterEvents = (ev: Event) => {
+  return ev.section === 'rolldown' && ev.method === 'DepositFerried'
+}

--- a/stash/src/scraper/L1LogScraper.ts
+++ b/stash/src/scraper/L1LogScraper.ts
@@ -10,10 +10,10 @@ import { timeseries } from '../connector/RedisConnector.js'
 import { setTimeout } from 'timers/promises'
 import logger from '../util/Logger.js'
 
-export const L1_CONFIRMED_STATUS = 'L1_CONFIRMED'
-export const L1_INITIATED_STATUS = 'L1_INITIATED'
+export const DEPOSIT_SUBMITTED_TO_L2 = 'SubmittedToL2'
+export const DEPOSIT_PENDING_ON_L1 = 'PendingOnL1'
 export const L2_CONFIRMED_STATUS = 'L2_CONFIRMED'
-export const L1_PROCESSED_STATUS = 'L1_PROCESSED'
+export const PROCESSED_STATUS = 'Processed'
 
 const keepProcessing = true
 
@@ -54,11 +54,11 @@ export const watchDepositAcceptedIntoQueue = async (
           .and('type')
           .equals('deposit')
           .and('status')
-          .equals(L1_INITIATED_STATUS)
+          .equals(DEPOSIT_PENDING_ON_L1)
           .returnFirst()
 
         if (existingTransaction) {
-          existingTransaction.status = L1_CONFIRMED_STATUS
+          existingTransaction.status = DEPOSIT_SUBMITTED_TO_L2
           existingTransaction.requestId = Number((log as any).args.requestId)
           const timestamp = new Date().toISOString()
           existingTransaction.updated = Date.parse(timestamp)
@@ -140,7 +140,7 @@ export const watchWithdrawalClosed = async (
           existingTransaction
         )
         if (existingTransaction) {
-          existingTransaction.status = L1_PROCESSED_STATUS
+          existingTransaction.status = PROCESSED_STATUS
           const timestamp = new Date().toISOString()
           existingTransaction.updated = Date.parse(timestamp)
           await withdrawalRepository.save(existingTransaction)
@@ -182,12 +182,15 @@ export const processRequests = async (api: ApiPromise, l1Chain: string) => {
         .gte(lastSavedProcessedRequestId)
         .and('requestId')
         .lte(lastProcessedRequestId)
+        .and('status')
+        .not.equals('Processed') //we want to skip ferried, already processed
         .return.all()
 
       for (const transaction of transactionsToProcess) {
-        transaction.status = 'PROCESSED'
+        transaction.status = 'Processed'
         const timestamp = new Date().toISOString()
         transaction.updated = Date.parse(timestamp)
+        transaction.closedBy = 'regular'
         await depositRepository.save(transaction)
       }
       await saveLastProcessedRequestId(

--- a/stash/src/service/SyncBlockService.ts
+++ b/stash/src/service/SyncBlockService.ts
@@ -4,6 +4,7 @@ import * as blocks from '../scraper/BlockScraper.js'
 import * as pools from '../scraper/PoolsScraper.js'
 import * as staking from '../scraper/StakingScraper.js'
 import * as withdrawals from '../scraper/WithdrawalScraper.js'
+import * as deposits from '../scraper/DepositScraper.js'
 import logger from '../util/Logger.js'
 
 export const initService = async () => {
@@ -15,6 +16,7 @@ export const initService = async () => {
     try {
       await blocks.processEvents(block)
       await withdrawals.processWithdrawalEvents(api, block)
+      await deposits.processFerriedDepositEvents(api, block)
       await pools.fetchPools(block)
       await staking.processStaking(api, block)
       await staking.processLiquidStaking(api, block)

--- a/stash/src/service/TracingService.ts
+++ b/stash/src/service/TracingService.ts
@@ -19,7 +19,7 @@ export const startTracingTransaction = async (
   const timestamp = new Date().toISOString()
   let status: string
   if (type === 'deposit') {
-    status = 'L1_INITIATED'
+    status = 'PendingOnL1'
   } else if (type === 'withdrawal') {
     status = 'L2_INITIATED'
   } else {
@@ -38,6 +38,7 @@ export const startTracingTransaction = async (
     amount,
     asset_chainId,
     asset_address,
+    closedBy: null,
   }
 
   try {

--- a/stash/test/api/tracing.api.test.ts
+++ b/stash/test/api/tracing.api.test.ts
@@ -50,7 +50,7 @@ describe('TracingController', () => {
           .get(`/tracing/tx/${transactionData.transaction.txHash}`)
           .expect(200)
         expect(response.body).toEqual(
-          expect.objectContaining({ status: 'L1_INITIATED' })
+          expect.objectContaining({ status: 'PendingOnL1' })
         )
       } catch (error) {
         logger.error(
@@ -98,7 +98,7 @@ describe('TracingController', () => {
       try {
         const response = await supertest(app)
           .get(
-            `/tracing/tx/listByAddress/${transactionData.transaction.address}/L1_INITIATED`
+            `/tracing/tx/listByAddress/${transactionData.transaction.address}/PendingOnL1`
           )
           .expect(200)
         expect(response.body).toHaveProperty('transactions')
@@ -109,7 +109,7 @@ describe('TracingController', () => {
         )
         expect(response.body.transactions[0]).toHaveProperty(
           'status',
-          'L1_INITIATED'
+          'PendingOnL1'
         )
       } catch (error) {
         logger.error(
@@ -164,7 +164,7 @@ describe('TracingController', () => {
       const errorMessage = 'No transactions found for this address'
       const wrongAddress = generateRandomAddress()
       const response = await supertest(app)
-        .get(`/tracing/tx/listByAddress/${wrongAddress}/L1_INITIATED`)
+        .get(`/tracing/tx/listByAddress/${wrongAddress}/PendingOnL1`)
         .expect(404)
       expect(response.body).toEqual(
         expect.objectContaining({

--- a/stash/test/depositScraper.test.ts
+++ b/stash/test/depositScraper.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, beforeEach, vi, expect } from 'vitest'
+import { processFerriedDepositEvents, processFerriedDeposit } from '../src/scraper/DepositScraper'
+import {depositRepository, withdrawalRepository} from '../src/repository/TransactionRepository'
+import { ApiPromise } from '@polkadot/api'
+import logger from '../src/util/Logger'
+
+vi.mock('../src/repository/TransactionRepository')
+vi.mock('@polkadot/api')
+vi.mock('../src/util/Logger')
+
+describe('DepositScraper', () => {
+  let mockApi: ApiPromise
+
+  beforeEach(() => {
+    mockApi = {} as ApiPromise
+    vi.clearAllMocks()
+  })
+
+  describe('processFerriedDepositEvents', () => {
+    it('should process ferried deposit events', async () => {
+      const mockBlock = {
+        events: [
+          [0, { section: 'rolldown', method: 'DepositFerried', data: { deposit: { requestId: { id: '1' } }, chain: 'testchain' } }],
+          [1, { section: 'other', method: 'OtherEvent', data: {} }],
+        ],
+      }
+
+      depositRepository.search.mockReturnValue({
+        where: vi.fn().mockReturnThis(),
+        equals: vi.fn().mockReturnThis(),
+        and: vi.fn().mockReturnThis(),
+        returnFirst: vi.fn().mockResolvedValue({
+          requestId: 1,
+          chain: 'testchain',
+          type: 'deposit',
+          status: 'SubmittedToL2',
+        }),
+      })
+
+      await processFerriedDepositEvents(mockApi, mockBlock as any)
+
+      expect(depositRepository.search).toHaveBeenCalled()
+      expect(depositRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'Processed',
+          closedBy: 'ferry',
+        })
+      )
+    })
+  })
+
+  describe('processFerriedDeposit', () => {
+    it('should process a single ferried deposit', async () => {
+      const mockEventData = {
+        deposit: { requestId: { id: '1' } },
+        chain: 'testchain',
+      }
+
+      depositRepository.search.mockReturnValue({
+        where: vi.fn().mockReturnThis(),
+        equals: vi.fn().mockReturnThis(),
+        and: vi.fn().mockReturnThis(),
+        returnFirst: vi.fn().mockResolvedValue({
+          requestId: 1,
+          chain: 'testchain',
+          type: 'deposit',
+          status: 'SubmittedToL2',
+        }),
+      })
+      vi.spyOn(depositRepository, 'save').mockResolvedValue({
+        requestId: 1,
+        chain: 'testchain',
+        type: 'deposit',
+        status: 'Processed',
+        closedBy: 'ferry',
+      })
+
+      const result = await processFerriedDeposit(mockApi, mockEventData)
+
+      expect(depositRepository.search).toHaveBeenCalled()
+      expect(depositRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'Processed',
+          closedBy: 'ferry',
+        })
+      )
+      expect(result).toEqual(
+        expect.objectContaining({
+          status: 'Processed',
+          closedBy: 'ferry',
+        })
+      )
+    })
+
+    it('should handle case when no matching transactions are found', async () => {
+      const mockEventData = {
+        deposit: { requestId: { id: '1' } },
+        chain: 'testchain',
+      }
+
+      depositRepository.search.mockReturnValue({
+        where: vi.fn().mockReturnThis(),
+        equals: vi.fn().mockReturnThis(),
+        and: vi.fn().mockReturnThis(),
+        returnFirst: vi.fn().mockResolvedValue(null),
+      })
+
+      const result = await processFerriedDeposit(mockApi, mockEventData)
+
+      expect(depositRepository.search).toHaveBeenCalled()
+      expect(depositRepository.save).not.toHaveBeenCalled()
+      expect(result).toBeUndefined()
+    })
+  })
+})

--- a/stash/test/l1.scraper.test.ts
+++ b/stash/test/l1.scraper.test.ts
@@ -2,9 +2,12 @@ import { describe, expect, vi, beforeEach, it } from 'vitest'
 import {
   watchDepositAcceptedIntoQueue,
   processRequests,
-  watchWithdrawalClosed
+  watchWithdrawalClosed,
 } from '../src/scraper/L1LogScraper'
-import { depositRepository, withdrawalRepository } from '../src/repository/TransactionRepository'
+import {
+  depositRepository,
+  withdrawalRepository,
+} from '../src/repository/TransactionRepository'
 import { timeseries } from '../src/connector/RedisConnector'
 import logger from '../src/util/Logger'
 import { holesky } from 'viem/chains'
@@ -15,7 +18,7 @@ vi.mock('../src/util/Logger')
 vi.mock('../src/scraper/L1LogScraper', () => ({
   watchDepositAcceptedIntoQueue: vi.fn(),
   processRequests: vi.fn(),
-  watchWithdrawalClosed: vi.fn()
+  watchWithdrawalClosed: vi.fn(),
 }))
 let keepProcessing = true
 
@@ -25,7 +28,7 @@ describe('L1LogScraper', () => {
     keepProcessing = true
   })
 
-  it('should update transaction status to L1_CONFIRMED on DepositAcceptedIntoQueue event', async () => {
+  it('should update transaction status to SubmittedToL2 on DepositAcceptedIntoQueue event', async () => {
     const mockApi = {}
     const mockPublicClient = {
       getBlockNumber: vi.fn().mockResolvedValue(100n),
@@ -43,7 +46,7 @@ describe('L1LogScraper', () => {
       and: vi.fn().mockReturnThis(),
       returnFirst: vi.fn().mockResolvedValue({
         txHash: '0x123',
-        status: 'L1_INITIATED',
+        status: 'PendingOnL1',
         type: 'deposit',
         requestId: null,
         updated: 0,
@@ -63,7 +66,7 @@ describe('L1LogScraper', () => {
       await depositRepository.search()
       await depositRepository.save({
         txHash: '0x123',
-        status: 'L1_CONFIRMED',
+        status: 'SubmittedToL2',
         requestId: 1,
       })
       await timeseries.client.hset()
@@ -82,14 +85,14 @@ describe('L1LogScraper', () => {
     expect(depositRepository.save).toHaveBeenCalledWith(
       expect.objectContaining({
         txHash: '0x123',
-        status: 'L1_CONFIRMED',
+        status: 'SubmittedToL2',
         requestId: 1,
       })
     )
     expect(timeseries.client.hset).toHaveBeenCalled()
   }, 10000)
 
-  it('should update transaction status to L1_PROCESSED on WithdrawalClosed event', async () => {
+  it('should update transaction status to Processed on WithdrawalClosed event', async () => {
     const mockApi = {}
     const mockPublicClient = {
       getBlockNumber: vi.fn().mockResolvedValue(100),
@@ -126,31 +129,31 @@ describe('L1LogScraper', () => {
       await withdrawalRepository.save({
         requestId: 1,
         txHash: '0x456',
-        status: 'L1_PROCESSED',
+        status: 'Processed',
       })
       await timeseries.client.hset(
-          `transactions_scanned:withdrawal:Ethereum`,
-          'lastBlock',
-          100
+        `transactions_scanned:withdrawal:Ethereum`,
+        'lastBlock',
+        100
       )
     })
 
     await watchWithdrawalClosed(
-        mockApi,
-        'http://chain.url',
-        holesky,
-        'Ethereum'
+      mockApi,
+      'http://chain.url',
+      holesky,
+      'Ethereum'
     )
 
     expect(mockPublicClient.getBlockNumber).toHaveBeenCalled()
     expect(mockPublicClient.getContractEvents).toHaveBeenCalled()
     expect(withdrawalRepository.search).toHaveBeenCalled()
     expect(withdrawalRepository.save).toHaveBeenCalledWith(
-        expect.objectContaining({
-          requestId: 1,
-          txHash: '0x456',
-          status: 'L1_PROCESSED',
-        })
+      expect.objectContaining({
+        requestId: 1,
+        txHash: '0x456',
+        status: 'Processed',
+      })
     )
     expect(timeseries.client.hset).toHaveBeenCalled()
   }, 10000)
@@ -170,7 +173,7 @@ describe('L1LogScraper', () => {
       address: '0x102',
       created: 1725613967329,
       updated: 1725613967329,
-      status: 'L1_CONFIRMED',
+      status: 'SubmittedToL2',
       type: 'deposit',
       chain: 'Ethereum',
       amount: '400000000000000000',
@@ -232,5 +235,4 @@ describe('L1LogScraper', () => {
       expect(timeseries.client.hset).toHaveBeenCalled()
     })
   })
-
 })

--- a/stash/test/tracing.test.ts
+++ b/stash/test/tracing.test.ts
@@ -1,121 +1,121 @@
-import { describe, expect, vi, beforeEach, it } from "vitest";
+import { describe, expect, vi, beforeEach, it } from 'vitest'
 import {
-    startTracingTransaction,
-    getTransactionsByAddress,
-    getStatusByTxHashOrEntityId,
-    getTransactionByEntityId,
-    getTransactionByTxHash,
-    findTransactionsByAddressAndStatus,
+  startTracingTransaction,
+  getTransactionsByAddress,
+  getStatusByTxHashOrEntityId,
+  getTransactionByEntityId,
+  getTransactionByTxHash,
+  findTransactionsByAddressAndStatus,
 } from '../src/service/TracingService'
-import { transactionRepository } from '../src/repository/TransactionRepository'
+import { depositRepository } from '../src/repository/TransactionRepository'
 
 vi.mock('../src/repository/TransactionRepository')
 vi.mock('../src/util/Logger')
 
 describe('TracingService', () => {
-    const mockTransaction = {
-        requestId: null,
+  const mockTransaction = {
+    requestId: null,
+    txHash: '0x102',
+    address: '0x102',
+    created: 1725613967329,
+    updated: 1725613967329,
+    status: 'PendingOnL1',
+    type: 'deposit',
+    chain: 'Ethereum',
+    amount: '400000000000000000',
+    asset_chainId: '0x106',
+    asset_address: '0x107',
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('startTracingTransaction should start tracing a new transaction', async () => {
+    depositRepository.search.mockReturnValue({
+      where: vi.fn().mockReturnThis(),
+      equals: vi.fn().mockReturnThis(),
+      and: vi.fn().mockReturnThis(),
+      return: { all: vi.fn().mockResolvedValue([]) },
+    })
+    depositRepository.save.mockResolvedValue(mockTransaction)
+
+    const result = await startTracingTransaction(mockTransaction)
+
+    expect(depositRepository.search).toHaveBeenCalled()
+    expect(depositRepository.save).toHaveBeenCalledWith(
+      expect.objectContaining({
         txHash: '0x102',
         address: '0x102',
-        created: 1725613967329,
-        updated: 1725613967329,
-        status: 'L1_INITIATED',
-        type: 'deposit',
-        chain: 'Ethereum',
-        amount: '400000000000000000',
-        asset_chainId: '0x106',
-        asset_address: '0x107',
-    }
+        status: 'PendingOnL1',
+      })
+    )
+    expect(result).toHaveProperty('txHash', '0x102')
+    expect(result).toHaveProperty('status', 'PendingOnL1')
+  })
 
-    beforeEach(() => {
-        vi.clearAllMocks()
+  it('getTransactionsByAddress should return transactions for a given address', async () => {
+    depositRepository.search.mockReturnValue({
+      where: vi.fn().mockReturnThis(),
+      equals: vi.fn().mockReturnThis(),
+      return: { all: vi.fn().mockResolvedValue([mockTransaction]) },
     })
 
-    it('startTracingTransaction should start tracing a new transaction', async () => {
-        transactionRepository.search.mockReturnValue({
-            where: vi.fn().mockReturnThis(),
-            equals: vi.fn().mockReturnThis(),
-            and: vi.fn().mockReturnThis(),
-            return: { all: vi.fn().mockResolvedValue([]) },
-        })
-        transactionRepository.save.mockResolvedValue(mockTransaction)
+    const result = await getTransactionsByAddress('0x102')
 
-        const result = await startTracingTransaction(mockTransaction)
+    expect(depositRepository.search).toHaveBeenCalled()
+    expect(result).toEqual([mockTransaction])
+  })
 
-        expect(transactionRepository.search).toHaveBeenCalled()
-        expect(transactionRepository.save).toHaveBeenCalledWith(
-            expect.objectContaining({
-                txHash: '0x102',
-                address: '0x102',
-                status: 'L1_INITIATED',
-            })
-        )
-        expect(result).toHaveProperty('txHash', '0x102')
-        expect(result).toHaveProperty('status', 'L1_INITIATED')
+  it('getStatusByTxHashOrEntityId should return status for a given txHash', async () => {
+    depositRepository.search.mockReturnValue({
+      where: vi.fn().mockReturnThis(),
+      equals: vi.fn().mockReturnThis(),
+      return: { all: vi.fn().mockResolvedValue([mockTransaction]) },
     })
 
-    it('getTransactionsByAddress should return transactions for a given address', async () => {
-        transactionRepository.search.mockReturnValue({
-            where: vi.fn().mockReturnThis(),
-            equals: vi.fn().mockReturnThis(),
-            return: { all: vi.fn().mockResolvedValue([mockTransaction]) },
-        })
+    const result = await getStatusByTxHashOrEntityId('0x102')
 
-        const result = await getTransactionsByAddress('0x102')
+    expect(depositRepository.search).toHaveBeenCalled()
+    expect(result).toBe('PendingOnL1')
+  })
 
-        expect(transactionRepository.search).toHaveBeenCalled()
-        expect(result).toEqual([mockTransaction])
+  it('getTransactionByEntityId should return transaction for a given entityId', async () => {
+    depositRepository.fetch.mockResolvedValue(mockTransaction)
+
+    const result = await getTransactionByEntityId('entityId')
+
+    expect(depositRepository.fetch).toHaveBeenCalledWith('entityId')
+    expect(result).toEqual(mockTransaction)
+  })
+
+  it('getTransactionByTxHash should return transaction for a given txHash', async () => {
+    depositRepository.search.mockReturnValue({
+      where: vi.fn().mockReturnThis(),
+      equals: vi.fn().mockReturnThis(),
+      return: { all: vi.fn().mockResolvedValue([mockTransaction]) },
     })
 
-    it('getStatusByTxHashOrEntityId should return status for a given txHash', async () => {
-        transactionRepository.search.mockReturnValue({
-            where: vi.fn().mockReturnThis(),
-            equals: vi.fn().mockReturnThis(),
-            return: { all: vi.fn().mockResolvedValue([mockTransaction]) },
-        })
+    const result = await getTransactionByTxHash('0x102')
 
-        const result = await getStatusByTxHashOrEntityId('0x102')
+    expect(depositRepository.search).toHaveBeenCalled()
+    expect(result).toEqual(mockTransaction)
+  })
 
-        expect(transactionRepository.search).toHaveBeenCalled()
-        expect(result).toBe('L1_INITIATED')
+  it('findTransactionsByAddressAndStatus should return transactions for a given address and status', async () => {
+    depositRepository.search.mockReturnValue({
+      where: vi.fn().mockReturnThis(),
+      equals: vi.fn().mockReturnThis(),
+      and: vi.fn().mockReturnThis(),
+      return: { all: vi.fn().mockResolvedValue([mockTransaction]) },
     })
 
-    it('getTransactionByEntityId should return transaction for a given entityId', async () => {
-        transactionRepository.fetch.mockResolvedValue(mockTransaction)
+    const result = await findTransactionsByAddressAndStatus(
+      '0x102',
+      'PendingOnL1'
+    )
 
-        const result = await getTransactionByEntityId('entityId')
-
-        expect(transactionRepository.fetch).toHaveBeenCalledWith('entityId')
-        expect(result).toEqual(mockTransaction)
-    })
-
-    it('getTransactionByTxHash should return transaction for a given txHash', async () => {
-        transactionRepository.search.mockReturnValue({
-            where: vi.fn().mockReturnThis(),
-            equals: vi.fn().mockReturnThis(),
-            return: { all: vi.fn().mockResolvedValue([mockTransaction]) },
-        })
-
-        const result = await getTransactionByTxHash('0x102')
-
-        expect(transactionRepository.search).toHaveBeenCalled()
-        expect(result).toEqual(mockTransaction)
-    })
-
-    it('findTransactionsByAddressAndStatus should return transactions for a given address and status', async () => {
-        transactionRepository.search.mockReturnValue({
-            where: vi.fn().mockReturnThis(),
-            equals: vi.fn().mockReturnThis(),
-            and: vi.fn().mockReturnThis(),
-            return: { all: vi.fn().mockResolvedValue([mockTransaction]) },
-        })
-
-        const result = await findTransactionsByAddressAndStatus(
-            '0x102',
-            'L1_INITIATED'
-        )
-
-        expect(transactionRepository.search).toHaveBeenCalled()
-        expect(result).toEqual([mockTransaction])
-    })
+    expect(depositRepository.search).toHaveBeenCalled()
+    expect(result).toEqual([mockTransaction])
+  })
 })


### PR DESCRIPTION
Start following the event DepositFerried on L2 and set deposit to Processed for the deposit requestId + chain that we get in the event (for tracked deposits only == the ones for which FE started the tracing).

Extend the model of Deposit schema to have additional field closedBy. 
closedBy = ferry on FerriedDeposit event received
closedBy = regular on lastProcessedRequestL2 for all the deposits not ferried but processed

Status names for deposits changed as:
L1_INITIATED → PendingOnL1
L1_CONFIRMED → SubmittedToL2
PROCESSED → Processed

Added and adjusted the tests.