### PR TITLE
FEAT/GASP-1605/dashboard feature

### DIFF
--- a/stash/api/GASP Holesky Develop.postman_environment.json
+++ b/stash/api/GASP Holesky Develop.postman_environment.json
@@ -7,9 +7,15 @@
 			"value": "https://gasp-stash-frontend-dot-direct-pixel-353917.oa.r.appspot.com",
 			"type": "default",
 			"enabled": true
+		},
+		{
+			"key": "wallet",
+			"value": "0x00",
+			"type": "default",
+			"enabled": true
 		}
 	],
 	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2024-11-08T11:22:06.379Z",
-	"_postman_exported_using": "Postman/11.18.4"
+	"_postman_exported_at": "2024-11-15T10:42:55.389Z",
+	"_postman_exported_using": "Postman/11.19.0"
 }

--- a/stash/api/_Stash.postman_collection.json
+++ b/stash/api/_Stash.postman_collection.json
@@ -646,6 +646,25 @@
 				}
 			},
 			"response": []
+		},
+		{
+			"name": "Dashboard for wallet",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{baseUrl}}/account/{{wallet}}/dashboard",
+					"host": [
+						"{{baseUrl}}"
+					],
+					"path": [
+						"account",
+						"{{wallet}}",
+						"dashboard"
+					]
+				}
+			},
+			"response": []
 		}
 	],
 	"variable": [

--- a/stash/src/app.ts
+++ b/stash/src/app.ts
@@ -15,6 +15,7 @@ import * as networkController from './controller/networkController.js'
 import * as tokenNetworkPortfolioController from './controller/tokenNetworkPortfolioController.js'
 import * as faucetController from './controller/FaucetController.js'
 import * as tracingController from './controller/TracingController.js'
+import * as tradingController from './controller/TradingController.js'
 
 import { createRequire } from 'module'
 const require = createRequire(import.meta.url)
@@ -118,6 +119,11 @@ app.get(
 
   tracingController.getATransactionByEntityId
 )
+
+// Dashboard endpoint
+app.get('/account/:wallet/dashboard', (req: Request, res: Response) => {
+  tradingController.getData(req, res)
+})
 
 // Coinmarketcap listing endpoints
 app.get('/coinmarketcap/v1/summary', coinmarketcapController.summary)

--- a/stash/src/app.ts
+++ b/stash/src/app.ts
@@ -121,9 +121,7 @@ app.get(
 )
 
 // Dashboard endpoint
-app.get('/account/:wallet/dashboard', (req: Request, res: Response) => {
-  tradingController.getData(req, res)
-})
+app.get('/account/:wallet/dashboard', tradingController.getData)
 
 // Coinmarketcap listing endpoints
 app.get('/coinmarketcap/v1/summary', coinmarketcapController.summary)

--- a/stash/src/controller/TradingController.ts
+++ b/stash/src/controller/TradingController.ts
@@ -1,0 +1,32 @@
+import { Request, Response } from 'express'
+import { getDataByWallet } from '../service/TradingService.js'
+import { getDataByWalletSchema } from '../schema/TradingSchema.js'
+import * as errorHandler from '../error/Handler.js'
+
+export const getData = async (req: Request, res: Response): Promise<void> => {
+  /*
+   #swagger.tags = ['Trading']
+   #swagger.summary = 'Get dashboard data.'
+   #swagger.description = "Retrieve the dashboard data."
+   #swagger.parameters['wallet'] = {
+     in: 'path',
+     description: 'Wallet to get dashboard data for',
+     required: true,
+     type: 'string'
+   }
+   #swagger.responses[200] = {
+      description: 'Successful response with dashboard data'
+   }
+   #swagger.responses[500] = {
+      description: 'Internal Server Error'
+   }
+  */
+  try {
+    const { wallet } = req.params
+    getDataByWalletSchema.validateSync({ wallet })
+    const data = await getDataByWallet(wallet)
+    res.json(data)
+  } catch (e) {
+    await errorHandler.handle(res, e)
+  }
+}

--- a/stash/src/model/Swap.ts
+++ b/stash/src/model/Swap.ts
@@ -1,0 +1,17 @@
+import { Schema } from 'redis-om'
+
+const swapSchema = new Schema(
+  'swaps',
+  {
+    account: { type: 'string' },
+    daysActive: { type: 'number' },
+    lastTradeTimestamp: { type: 'date' },
+    totalVolumes: { type: 'number' },
+    totalTrades: { type: 'number' },
+  },
+  {
+    dataStructure: 'JSON',
+  }
+)
+
+export { swapSchema }

--- a/stash/src/repository/TransactionRepository.ts
+++ b/stash/src/repository/TransactionRepository.ts
@@ -1,6 +1,7 @@
 import { Client } from 'redis-om'
 import { depositSchema } from '../model/Deposit.js'
 import { withdrawalSchema } from '../model/Withdrawal.js'
+import { swapSchema } from '../model/Swap.js'
 import { getTimeseriesUrl } from '../connector/RedisConnector.js'
 import logger from '../util/Logger.js'
 
@@ -9,6 +10,7 @@ await client.open(getTimeseriesUrl())
 
 const depositRepository = client.fetchRepository(depositSchema)
 const withdrawalRepository = client.fetchRepository(withdrawalSchema)
+const swapRepository = client.fetchRepository(swapSchema)
 
 try {
   await depositRepository.createIndex()
@@ -32,5 +34,16 @@ try {
     message: 'Withdrawal index already exists, skipping creation.',
   })
 }
+try {
+  await swapRepository.createIndex()
+} catch (error) {
+  if (!error.message.includes('Swap index already exists')) {
+    throw error
+  }
+  logger.log({
+    level: 'info',
+    message: 'Swap index already exists, skipping creation.',
+  })
+}
 
-export { depositRepository, withdrawalRepository }
+export { depositRepository, withdrawalRepository, swapRepository }

--- a/stash/src/schema/TradingSchema.ts
+++ b/stash/src/schema/TradingSchema.ts
@@ -1,0 +1,8 @@
+import * as yup from 'yup'
+
+export const getDataByWalletSchema = yup.object().shape({
+  wallet: yup
+    .string()
+    .required('wallet is required')
+    .matches(/^0x/, 'wallet address must begin with 0x'),
+})

--- a/stash/src/scraper/SwapScraper.ts
+++ b/stash/src/scraper/SwapScraper.ts
@@ -65,11 +65,11 @@ export const processSwapEvents = async (api: ApiPromise, block: Block) => {
   }
 }
 
-const filterEvents = (ev: Event) => {
+export const filterEvents = (ev: Event) => {
   return ev.section === 'xyk' && ev.method === 'AssetsSwapped'
 }
 
-async function decimalsFromTokenId(api: ApiPromise, tokenId: any) {
+export async function decimalsFromTokenId(api: ApiPromise, tokenId: any) {
   const tokens = await api.query.assetRegistry.metadata.entries()
   const assets = tokens.reduce((obj, [key, value]) => {
     const [tokenId] = key.args
@@ -83,7 +83,7 @@ async function decimalsFromTokenId(api: ApiPromise, tokenId: any) {
   return assets[tokenId.toString()] || null
 }
 
-async function calculateVolume(
+export async function calculateVolume(
   tokenId: string,
   decimals: number,
   volume: string

--- a/stash/src/scraper/SwapScraper.ts
+++ b/stash/src/scraper/SwapScraper.ts
@@ -1,0 +1,111 @@
+import { ApiPromise } from '@polkadot/api'
+import { Block, Event } from './BlockScraper'
+import _ from 'lodash'
+import { swapRepository } from '../repository/TransactionRepository.js'
+import logger from '../util/Logger.js'
+import * as priceDiscoveryService from '../service/PriceDiscoveryService.js'
+
+export const processSwapEvents = async (api: ApiPromise, block: Block) => {
+  const events = _.chain(block.events)
+    .filter((ev) => filterEvents(ev[1]))
+    .groupBy(([idx, _]) => idx)
+    .map((evs, _) => evs.map(([_, ev]) => ev))
+    .value()
+  if (events.length > 0) {
+    for (const eventGroup of events) {
+      for (const event of eventGroup) {
+        try {
+          logger.info('event asset swapped received: ', event)
+          const account = event.data[0]
+          const tokenId = event.data[1][1]
+          const eventVolume = event.data[3]
+          const existingRecord = await swapRepository
+            .search()
+            .where('account')
+            .equals(account)
+            .returnFirst()
+          if (existingRecord) {
+            logger.info('existing record found: ', existingRecord)
+            const currentDate = new Date()
+            const lastTradeDate = new Date(existingRecord.lastTradeTimestamp)
+            existingRecord.daysActive =
+              currentDate.toDateString() === lastTradeDate.toDateString()
+                ? existingRecord.daysActive
+                : existingRecord.daysActive + 1
+            existingRecord.lastTradeTimestamp = currentDate
+            existingRecord.totalTrades += 1
+            const { decimals } = await decimalsFromTokenId(api, tokenId)
+            const newTotalVolume = await calculateVolume(
+              tokenId,
+              decimals,
+              eventVolume
+            )
+            if (newTotalVolume !== null) {
+              existingRecord.totalVolume = newTotalVolume
+            }
+            await swapRepository.save(existingRecord)
+          } else {
+            //we got the trade for new account
+            const { decimals } = await decimalsFromTokenId(api, tokenId)
+            const volume = await calculateVolume(tokenId, decimals, eventVolume)
+            const newRecord = {
+              account: account,
+              lastTradeTimestamp: new Date(),
+              daysActive: 1,
+              totalVolume: volume,
+              totalTrades: 1,
+            }
+            await swapRepository.save(newRecord)
+          }
+        } catch (e) {
+          logger.error('Error processing swap event:', e)
+        }
+      }
+    }
+  }
+}
+
+const filterEvents = (ev: Event) => {
+  return ev.section === 'xyk' && ev.method === 'AssetsSwapped'
+}
+
+async function decimalsFromTokenId(api: ApiPromise, tokenId: any) {
+  const tokens = await api.query.assetRegistry.metadata.entries()
+  const assets = tokens.reduce((obj, [key, value]) => {
+    const [tokenId] = key.args
+    const { decimals } = value.unwrap()
+    obj[tokenId.toString()] = {
+      id: tokenId.toString(),
+      decimals: Number(decimals.toPrimitive()),
+    }
+    return obj
+  }, {})
+  return assets[tokenId.toString()] || null
+}
+
+async function calculateVolume(
+  tokenId: string,
+  decimals: number,
+  volume: string
+): Promise<number | string> {
+  try {
+    // const response = await getCoinInfo(tokenSymbol)
+    const response = await priceDiscoveryService.priceDiscovery(tokenId)
+    const currentPrice = response.current_price['usd']
+    const volumeString = volume.toString().replace(/,/g, '')
+    const volumeBigInt = BigInt(volumeString)
+    const finalValue =
+      parseFloat(currentPrice) * (Number(volumeBigInt) / Math.pow(10, decimals))
+    console.log('current price: ', currentPrice)
+    console.log('decimals: ', decimals)
+    console.log('final value in dolars: ', finalValue)
+
+    return finalValue
+  } catch (error) {
+    logger.error(
+      `Error: Unable to retrieve token price data for token id ${tokenId}`,
+      error
+    )
+    return null
+  }
+}

--- a/stash/src/service/SyncBlockService.ts
+++ b/stash/src/service/SyncBlockService.ts
@@ -5,6 +5,7 @@ import * as pools from '../scraper/PoolsScraper.js'
 import * as staking from '../scraper/StakingScraper.js'
 import * as withdrawals from '../scraper/WithdrawalScraper.js'
 import * as deposits from '../scraper/DepositScraper.js'
+import * as swaps from '../scraper/SwapScraper.js'
 import logger from '../util/Logger.js'
 
 export const initService = async () => {
@@ -20,6 +21,7 @@ export const initService = async () => {
       await pools.fetchPools(block)
       await staking.processStaking(api, block)
       await staking.processLiquidStaking(api, block)
+      await swaps.processSwapEvents(api, block)
       await store.saveLatest({
         timestamp: block.timestamp,
         block: block.number,

--- a/stash/src/service/TradingService.ts
+++ b/stash/src/service/TradingService.ts
@@ -1,0 +1,9 @@
+import { swapRepository } from '../repository/TransactionRepository.js'
+
+export const getDataByWallet = async (wallet: string): Promise<object[]> => {
+  return await swapRepository
+    .search()
+    .where('account')
+    .equals(wallet)
+    .return.all()
+}

--- a/stash/swagger-output.json
+++ b/stash/swagger-output.json
@@ -1136,6 +1136,32 @@
         }
       }
     },
+    "/account/{wallet}/dashboard": {
+      "get": {
+        "tags": [
+          "Trading"
+        ],
+        "summary": "Get dashboard data.",
+        "description": "Retrieve the dashboard data.",
+        "parameters": [
+          {
+            "name": "wallet",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "Wallet to get dashboard data for"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response with dashboard data"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
     "/coinmarketcap/v1/summary": {
       "get": {
         "tags": [

--- a/stash/test/trading.test.ts
+++ b/stash/test/trading.test.ts
@@ -4,7 +4,7 @@ import { swapRepository } from '../src/repository/TransactionRepository'
 
 vi.mock('../src/repository/TransactionRepository')
 
-describe.skip('TradingService', () => {
+describe('TradingService', () => {
   describe('getDataByWallet', () => {
     beforeEach(() => {
       vi.clearAllMocks()

--- a/stash/test/trading.unit.test.ts
+++ b/stash/test/trading.unit.test.ts
@@ -4,7 +4,7 @@ import { swapRepository } from '../src/repository/TransactionRepository'
 
 vi.mock('../src/repository/TransactionRepository')
 
-describe('TradingService', () => {
+describe.skip('TradingService', () => {
   describe('getDataByWallet', () => {
     beforeEach(() => {
       vi.clearAllMocks()

--- a/stash/test/trading.unit.test.ts
+++ b/stash/test/trading.unit.test.ts
@@ -11,19 +11,19 @@ describe('TradingService', () => {
     })
 
     it('should return data for a valid wallet', async () => {
-      const mockData = [{ id: '1', account: 'wallet1' }]
+      const mockData = [{ id: '1', account: '0xaccount' }]
       ;(swapRepository.search as vi.Mock).mockReturnValue({
         where: vi.fn().mockReturnThis(),
         equals: vi.fn().mockReturnThis(),
         return: { all: vi.fn().mockResolvedValue(mockData) },
       })
 
-      const result = await getDataByWallet('wallet1')
+      const result = await getDataByWallet('0xaccount')
 
       expect(result).toEqual(mockData)
       expect(swapRepository.search().where).toHaveBeenCalledWith('account')
-      expect(swapRepository.search().where('account').equals).toHaveBeenCalledWith('wallet1')
-      expect(swapRepository.search().where('account').equals('wallet1').return.all).toHaveBeenCalled()
+      expect(swapRepository.search().where('account').equals).toHaveBeenCalledWith('0xaccount')
+      expect(swapRepository.search().where('account').equals('0xaccount').return.all).toHaveBeenCalled()
     })
 
     it('should return an empty array for a wallet with no data', async () => {
@@ -33,12 +33,12 @@ describe('TradingService', () => {
         return: { all: vi.fn().mockResolvedValue([]) },
       })
 
-      const result = await getDataByWallet('wallet2')
+      const result = await getDataByWallet('0xaccount2')
 
       expect(result).toEqual([])
       expect(swapRepository.search().where).toHaveBeenCalledWith('account')
-      expect(swapRepository.search().where('account').equals).toHaveBeenCalledWith('wallet2')
-      expect(swapRepository.search().where('account').equals('wallet2').return.all).toHaveBeenCalled()
+      expect(swapRepository.search().where('account').equals).toHaveBeenCalledWith('0xaccount2')
+      expect(swapRepository.search().where('account').equals('0xaccount2').return.all).toHaveBeenCalled()
     })
   })
 })

--- a/stash/test/trading.unit.test.ts
+++ b/stash/test/trading.unit.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { getDataByWallet } from '../src/service/TradingService'
+import { swapRepository } from '../src/repository/TransactionRepository'
+
+vi.mock('../src/repository/TransactionRepository')
+
+describe('TradingService', () => {
+  describe('getDataByWallet', () => {
+    beforeEach(() => {
+      vi.clearAllMocks()
+    })
+
+    it('should return data for a valid wallet', async () => {
+      const mockData = [{ id: '1', account: 'wallet1' }]
+      ;(swapRepository.search as vi.Mock).mockReturnValue({
+        where: vi.fn().mockReturnThis(),
+        equals: vi.fn().mockReturnThis(),
+        return: { all: vi.fn().mockResolvedValue(mockData) },
+      })
+
+      const result = await getDataByWallet('wallet1')
+
+      expect(result).toEqual(mockData)
+      expect(swapRepository.search().where).toHaveBeenCalledWith('account')
+      expect(swapRepository.search().where('account').equals).toHaveBeenCalledWith('wallet1')
+      expect(swapRepository.search().where('account').equals('wallet1').return.all).toHaveBeenCalled()
+    })
+
+    it('should return an empty array for a wallet with no data', async () => {
+      ;(swapRepository.search as vi.Mock).mockReturnValue({
+        where: vi.fn().mockReturnThis(),
+        equals: vi.fn().mockReturnThis(),
+        return: { all: vi.fn().mockResolvedValue([]) },
+      })
+
+      const result = await getDataByWallet('wallet2')
+
+      expect(result).toEqual([])
+      expect(swapRepository.search().where).toHaveBeenCalledWith('account')
+      expect(swapRepository.search().where('account').equals).toHaveBeenCalledWith('wallet2')
+      expect(swapRepository.search().where('account').equals('wallet2').return.all).toHaveBeenCalled()
+    })
+  })
+})

--- a/stash/test/tradingScraper.test.ts
+++ b/stash/test/tradingScraper.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { processSwapEvents, calculateVolume, decimalsFromTokenId } from '../src/scraper/SwapScraper'
+import {swapRepository} from '../src/repository/TransactionRepository'
+import logger from '../src/util/Logger'
+import * as priceDiscoveryService from '../src/service/PriceDiscoveryService'
+import { ApiPromise } from '@polkadot/api'
+
+vi.mock('../src/repository/TransactionRepository')
+vi.mock('../src/util/Logger')
+vi.mock('../src/service/PriceDiscoveryService')
+
+describe('processSwapEvents', () => {
+  let mockApi: ApiPromise
+  let mockBlock: any
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApi = {} as ApiPromise
+    mockBlock = {
+      events: [
+        [
+          0,
+          {
+            section: 'xyk',
+            method: 'AssetsSwapped',
+            data: ['0xaccount', ['0', '1'], null, '10000000000000000000000'],
+          },
+        ],
+      ],
+    }
+  })
+
+  it('should process swap events and update existing record', async () => {
+    const mockRecord = {
+      account: '0xaccount',
+      lastTradeTimestamp: new Date().getTime(),
+      daysActive: 1,
+      totalVolume: 0.0001,
+      totalTrades: 1,
+    }
+    vi.spyOn(swapRepository, 'search').mockReturnValue({
+      where: vi.fn().mockReturnThis(),
+      equals: vi.fn().mockReturnThis(),
+      returnFirst: vi.fn().mockResolvedValue(mockRecord),
+    } as any)
+    vi.spyOn(priceDiscoveryService, 'priceDiscovery').mockResolvedValue({
+      current_price: { usd: '1' },
+    })
+    const mockSwapData = {
+      account: '0xaccount',
+      daysActive: 1,
+      lastTradeTimestamp: '1458859082092.11',
+      totalVolume: expect.any(Number),
+      totalTrades: expect.any(Number),
+    }
+    vi.spyOn(swapRepository, 'save').mockResolvedValue(mockSwapData)
+    await processSwapEvents(mockApi, mockBlock)
+
+    expect.objectContaining({
+      account: '0xaccount',
+      daysActive: 1,
+      lastTradeTimestamp: '1458859082092.11',
+      totalVolume: expect.any(Number),
+      totalTrades: expect.any(Number),
+    })
+  })
+
+  it('should process swap events and create new record', async () => {
+    vi.spyOn(swapRepository, 'search').mockReturnValue({
+      where: vi.fn().mockReturnThis(),
+      equals: vi.fn().mockReturnThis(),
+      returnFirst: vi.fn().mockResolvedValue(null),
+    } as any)
+    vi.spyOn(priceDiscoveryService, 'priceDiscovery').mockResolvedValue({
+      current_price: { usd: '1' },
+    })
+    const mockSwapData = {
+      account: '0xaccount',
+      daysActive: 1,
+      lastTradeTimestamp: '1458859082092.11',
+      totalVolume: expect.any(Number),
+      totalTrades: expect.any(Number),
+    }
+    vi.spyOn(swapRepository, 'save').mockResolvedValue(mockSwapData)
+    await processSwapEvents(mockApi, mockBlock)
+
+    expect.objectContaining({
+      account: '0xaccount',
+      daysActive: 1,
+      lastTradeTimestamp: '1458859082092.11',
+      totalVolume: expect.any(Number),
+      totalTrades: expect.any(Number),
+    })
+  })
+
+  it('should log an error if processing fails', async () => {
+    const error = new Error('Test error')
+    vi.spyOn(swapRepository, 'search').mockReturnValue({
+      where: vi.fn().mockReturnThis(),
+      equals: vi.fn().mockReturnThis(),
+      returnFirst: vi.fn().mockRejectedValue(error),
+    } as any)
+
+    await processSwapEvents(mockApi, mockBlock)
+
+    expect(logger.error).toHaveBeenCalledWith('Error processing swap event:', error)
+  })
+})
+
+describe('calculateVolume', () => {
+  it('should calculate volume correctly', async () => {
+    vi.spyOn(priceDiscoveryService, 'priceDiscovery').mockResolvedValue({
+      current_price: { usd: '1' },
+    })
+
+    const result = await calculateVolume('tokenId1', 18, '10000000000000000000000')
+
+    expect(result).toBe(10000)
+  })
+
+  it('should return null if price discovery fails', async () => {
+    const error = new Error('Test error')
+    vi.spyOn(priceDiscoveryService, 'priceDiscovery').mockRejectedValue(error)
+
+    const result = await calculateVolume('1', 18, '10000000000000000000000')
+
+    expect(result).toBeNull()
+    expect(logger.error).toHaveBeenCalledWith(
+      'Error: Unable to retrieve token price data for token id 1',
+      error
+    )
+  })
+})
+
+describe('decimalsFromTokenId', () => {
+  let mockApi: ApiPromise
+
+  beforeEach(() => {
+    mockApi = {
+      query: {
+        assetRegistry: {
+          metadata: {
+            entries: vi.fn().mockResolvedValue([
+              [{ args: ['1'] }, { unwrap: () => ({ decimals: { toPrimitive: () => 18 } }) }],
+            ]),
+          },
+        },
+      },
+    } as unknown as ApiPromise
+  })
+
+  it('should return decimals for a valid tokenId', async () => {
+    const result = await decimalsFromTokenId(mockApi, '1')
+
+    expect(result).toEqual({ id: '1', decimals: 18 })
+  })
+
+  it('should return null for an invalid tokenId', async () => {
+    const result = await decimalsFromTokenId(mockApi, 'invalidTokenId')
+
+    expect(result).toBeNull()
+  })
+})


### PR DESCRIPTION
Created a background job in stash to pickup xyk.AssetsSwapped events on the node and save them in stash. 
Api for accessing saved data: /account/{wallet}/dashboard
Details in the ticket [here](https://mangatafinance.atlassian.net/browse/GASP-1605) 