### PR TITLE
Chore/GASP-1770/use price history for tokens in token portfolio stash endpoint

### DIFF
--- a/stash/src/controller/tokenNetworkPortfolioController.ts
+++ b/stash/src/controller/tokenNetworkPortfolioController.ts
@@ -90,7 +90,7 @@ export const tokenNetworkPortfolio = async (req: Request, res: Response) => {
         } else {
           balanceInUsdCalculated = new Decimal(0.0) //no value
         }
-        console.log(
+        logger.info(
           'FINAL: freeBalance:',
           freeBalance.toString(),
           'tokenBalanceInUsd:',

--- a/stash/src/controller/tokenNetworkPortfolioController.ts
+++ b/stash/src/controller/tokenNetworkPortfolioController.ts
@@ -4,7 +4,6 @@ import MangataClient from '../connector/MangataNode.js'
 import { BN } from '@polkadot/util'
 import {
   priceDiscovery,
-  getAsset,
   priceHistory,
 } from '../service/PriceDiscoveryService.js'
 import { Decimal } from 'decimal.js'

--- a/stash/src/controller/tokenNetworkPortfolioController.ts
+++ b/stash/src/controller/tokenNetworkPortfolioController.ts
@@ -68,13 +68,13 @@ export const tokenNetworkPortfolio = async (req: Request, res: Response) => {
                 ? priceHistoryData.prices[
                     priceHistoryData.prices.length - 1
                   ][1].toString()
-                : '0.00' //if there is
+                : '0.00' //if there is no price-history data fallback to 0.00
           } catch (error) {
             logger.error(
               `Error fetching token info and balanceInUSD for tokenId ${tokenId}, it might be a pool or a LP token:`,
               error
             )
-            tokenBalanceInUsd = '0' //no price-discovery + its pool/LP token
+            tokenBalanceInUsd = '0.00' //no price-discovery + its pool/LP token
           }
         }
 

--- a/stash/src/service/PriceDiscoveryService.ts
+++ b/stash/src/service/PriceDiscoveryService.ts
@@ -95,7 +95,7 @@ const refresh = async () => {
   }
 }
 
-export const getAsset = (id: string, isPool: boolean) => {
+const getAsset = (id: string, isPool: boolean) => {
   isPool ? poolSchema.validateSync(id) : assetSchema.validateSync(id)
   return assetInfo.get(id)
 }

--- a/stash/src/service/PriceDiscoveryService.ts
+++ b/stash/src/service/PriceDiscoveryService.ts
@@ -95,7 +95,7 @@ const refresh = async () => {
   }
 }
 
-const getAsset = (id: string, isPool: boolean) => {
+export const getAsset = (id: string, isPool: boolean) => {
   isPool ? poolSchema.validateSync(id) : assetSchema.validateSync(id)
   return assetInfo.get(id)
 }


### PR DESCRIPTION
For tokens that have no price-discovery (don't have a direct pool with ETH) we will fall back to price-history latest price we have. 
For LP/pools we will show 0.00 for prices in token-portfolio.