### PR TITLE
[GASP-1841] fixes panic on empty task response

### DIFF
--- a/avs-aggregator/rpc_server.go
+++ b/avs-aggregator/rpc_server.go
@@ -139,6 +139,13 @@ type SignedTaskResponse struct {
 func (agg *Aggregator) ProcessSignedTaskResponse(signedTaskResponse *SignedTaskResponse, reply *bool) error {
 	agg.logger.Info("Received signed task response", "response", signedTaskResponse, "operatorId", signedTaskResponse.OperatorId.LogValue())
 
+	if len(signedTaskResponse.OpTaskResponse) < 2 ||
+		len(signedTaskResponse.RdTaskResponse) < 2 ||
+		signedTaskResponse.BlsSignature.G1Point == nil {
+		agg.logger.Error("Invalid task response")
+		return BadTaskResponseError500
+	}
+	
 	op_task_response_bytes, err := hex.DecodeString(signedTaskResponse.OpTaskResponse[2:])
 	if err != nil {
 		agg.logger.Error("Failed to get op_task_response_bytes", "err", err)


### PR DESCRIPTION
the hex decode expected the task strings to start with 0x, with at least the length of 2
on empty string response the code panics