### PR TITLE
fix: Prevent ferry from transfering native funds to contract in case ERC20 withdrawal

### DIFF
--- a/ferry-withdrawal/src/CloserService.ts
+++ b/ferry-withdrawal/src/CloserService.ts
@@ -88,7 +88,8 @@ class CloserService {
 							}) !== undefined;
 
 						return (
-							(shouldBeClosed || await this.stash.shouldBeClosed(request.hash)) &&
+							(shouldBeClosed ||
+								(await this.stash.shouldBeClosed(request.hash))) &&
 							!(await this.l1.isClosed(request.hash))
 						);
 					} else {

--- a/ferry-withdrawal/src/l1/L1Api.ts
+++ b/ferry-withdrawal/src/l1/L1Api.ts
@@ -316,7 +316,9 @@ class L1Api implements L1Interface {
 		});
 
 		const native_addr = await this.getNativeTokenAddress();
-		if (u8aToHex(withdrawal.tokenAddress) !== u8aToHex(native_addr)) {
+		const isNativeToken =
+			u8aToHex(withdrawal.tokenAddress) === u8aToHex(native_addr);
+		if (!isNativeToken) {
 			// TODO: submit as a batch
 			const approveRequest = await this.client.simulateContract({
 				account: acc,
@@ -357,7 +359,7 @@ class L1Api implements L1Interface {
 			args: [withdrawalToViemFormat(withdrawal)],
 			maxFeePerGas: maxFeeInWei,
 			maxPriorityFeePerGas: maxPriorityFeePerGasInWei,
-			value: withdrawal.amount - withdrawal.ferryTip,
+			value: isNativeToken ? withdrawal.amount - withdrawal.ferryTip : 0n,
 		});
 
 		const ferrytxHash = await wc.writeContract(ferryRequest.request);

--- a/ferry-withdrawal/tests/L1Interface.test.ts
+++ b/ferry-withdrawal/tests/L1Interface.test.ts
@@ -230,6 +230,31 @@ describe('L1Interface', () => {
     expect(await l1Api.isFerried(hashWithdrawal(withdrawal))).toBeTruthy();
     }, {timeout: 10000});
 
+  it('non native ferryWithdrawal works doest not transfer native token to contract', async () => {
+	const publicClient = createPublicClient({
+		transport: webSocket(WS_URI, { retryCount: 5 }),
+	});
+    const randomAddress = getRandomUintArray(20);
+
+    const contactBalanceBefore = await publicClient.getBalance({ address: MANGATA_CONTRACT_ADDRESS });
+    const withdrawal: Withdrawal = {
+        requestId: 1n,
+        withdrawalRecipient: randomAddress,
+        tokenAddress: TOKEN_ADDRESS,
+        amount: 1n,
+        ferryTip: 0n,
+        hash: hexToU8a("0x0000000000000000000000000000000000000000000000000000000000000000", 32),
+    };
+
+    const privateKey = hexToU8a("0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80");
+    expect(await l1Api.isFerried(hashWithdrawal(withdrawal))).toBeFalsy();
+    await l1Api.ferry(withdrawal, privateKey);
+    const contactBalanceAfter = await publicClient.getBalance({ address: MANGATA_CONTRACT_ADDRESS });
+    expect(await l1Api.isFerried(hashWithdrawal(withdrawal))).toBeTruthy();
+    expect(contactBalanceBefore).toEqual(contactBalanceAfter);
+    }, {timeout: 10000});
+
+
   it('native ferryWithdrawal works', async () => {
     const randomAddress = getRandomUintArray(20);
 


### PR DESCRIPTION
- **reproduce scenario where ferry sends native token while ferring non native withdrawal**
- **transfer native funds to rolldown only when ferring native withdrawals**
