### PR TITLE
chore: post release alignment

### DIFF
--- a/contracts/script/MultiStage.s.sol
+++ b/contracts/script/MultiStage.s.sol
@@ -112,7 +112,7 @@ contract MultiStage is Script, Utils {
 
         if (envHash == _stringToHash("arbitrum-sepolia")) {
             require(
-                !outputExists("arbitrum_rolldown_output") && !outputExists("arbitrum_gmrs_output"),
+                !outputExists("rolldown_output") && !outputExists("gmrs_output"),
                 "Contracts already deployed on Arbitrum Sepolia"
             );
 
@@ -122,7 +122,7 @@ contract MultiStage is Script, Utils {
 
         if (envHash == _stringToHash("base-sepolia")) {
             require(
-                !outputExists("base_rolldown_output") && !outputExists("base_gmrs_output"),
+                !outputExists("rolldown_output") && !outputExists("gmrs_output"),
                 "Contracts already deployed on Base Sepolia"
             );
 
@@ -142,7 +142,7 @@ contract MultiStage is Script, Utils {
 
         if (envHash == _stringToHash("megaeth-testnet")) {
             require(
-                !outputExists("megaeth_rolldown_output") && !outputExists("megaeth_gmrs_output"),
+                !outputExists("rolldown_output") && !outputExists("gmrs_output"),
                 "Contracts already deployed on Megaeth Testnet"
             );
 

--- a/contracts/script/config/10143/deploy.config.json
+++ b/contracts/script/config/10143/deploy.config.json
@@ -1,0 +1,12 @@
+{
+  "chainInfo": {
+    "chainId": 10143
+  },
+  "allow_non_root_gmrs_init": true,
+  "permissions": {
+    "owner": "0xeACEe31DC9a639ACc345f78F4D00979ff0683337",
+    "upgrader": "0xeACEe31DC9a639ACc345f78F4D00979ff0683337",
+    "rolldownUpdater": "0xeACEe31DC9a639ACc345f78F4D00979ff0683337",
+    "gmrsUpdater": "0xeACEe31DC9a639ACc345f78F4D00979ff0683337"
+  }
+}

--- a/contracts/script/config/6342/deploy.config.json
+++ b/contracts/script/config/6342/deploy.config.json
@@ -1,0 +1,12 @@
+{
+  "chainInfo": {
+    "chainId": 6342
+  },
+  "allow_non_root_gmrs_init": true,
+  "permissions": {
+    "owner": "0xeACEe31DC9a639ACc345f78F4D00979ff0683337",
+    "upgrader": "0xeACEe31DC9a639ACc345f78F4D00979ff0683337",
+    "rolldownUpdater": "0xeACEe31DC9a639ACc345f78F4D00979ff0683337",
+    "gmrsUpdater": "0xeACEe31DC9a639ACc345f78F4D00979ff0683337"
+  }
+}

--- a/contracts/script/output/10143/gmrs_output.json
+++ b/contracts/script/output/10143/gmrs_output.json
@@ -1,0 +1,24 @@
+{
+  "addresses": {
+    "gaspErc20Mock": "0xF5C9b2ee7bb091E245c92feCb9218Bf952BEA637",
+    "gmrs": "0x2a1B7d69017D14dAf08D24911596e8C244c9E2a8",
+    "gmrsImplementation": "0x109e8d2637449F651666f2F528EC9a699693cF47",
+    "gmrsPauseReg": "0xD2333E11ea617E30fb97900f6ac9782A85f233e7",
+    "gmrsProxyAdmin": "0x96A14F6eb10a67167249Adb64149F33f5D6e8f2b",
+    "rolldown": "0xfd6A45621DDfeBF94C082e60E0De92aA305a97a1",
+    "rolldownImplementation": "0xdFC848742eceB4B5e245D316d909B842466988a3",
+    "rolldownProxyAdmin": "0xB1F013a1e24aaA62b75eF6ca2BEAF0eeAE8A939a"
+  },
+  "chainInfo": {
+    "chainId": 10143,
+    "deploymentBlock": 8664957
+  },
+  "permissions": {
+    "gmrsOwner": "0xeACEe31DC9a639ACc345f78F4D00979ff0683337",
+    "gmrsUpdater": "0xeACEe31DC9a639ACc345f78F4D00979ff0683337",
+    "gmrsUpgrader": "0xeACEe31DC9a639ACc345f78F4D00979ff0683337",
+    "rolldownOwner": "0xeACEe31DC9a639ACc345f78F4D00979ff0683337",
+    "rolldownUpdater": "0xeACEe31DC9a639ACc345f78F4D00979ff0683337",
+    "rolldownUpgrader": "0xeACEe31DC9a639ACc345f78F4D00979ff0683337"
+  }
+}

--- a/contracts/script/output/10143/rolldown_output.json
+++ b/contracts/script/output/10143/rolldown_output.json
@@ -1,0 +1,17 @@
+{
+  "addresses": {
+    "gaspErc20Mock": "0xF5C9b2ee7bb091E245c92feCb9218Bf952BEA637",
+    "rolldown": "0xfd6A45621DDfeBF94C082e60E0De92aA305a97a1",
+    "rolldownImplementation": "0xdFC848742eceB4B5e245D316d909B842466988a3",
+    "rolldownProxyAdmin": "0xB1F013a1e24aaA62b75eF6ca2BEAF0eeAE8A939a"
+  },
+  "chainInfo": {
+    "chainId": 10143,
+    "deploymentBlock": 8664957
+  },
+  "permissions": {
+    "rolldownOwner": "0xeACEe31DC9a639ACc345f78F4D00979ff0683337",
+    "rolldownUpdater": "0xeACEe31DC9a639ACc345f78F4D00979ff0683337",
+    "rolldownUpgrader": "0xeACEe31DC9a639ACc345f78F4D00979ff0683337"
+  }
+}

--- a/contracts/script/upgrades-and-migrations/holesky/S1_U1MX_FinalizerTaskManager/S1_U1MX_FinalizerTaskManager.sh
+++ b/contracts/script/upgrades-and-migrations/holesky/S1_U1MX_FinalizerTaskManager/S1_U1MX_FinalizerTaskManager.sh
@@ -6,7 +6,7 @@
 # Once sure - run with `--broadcast`
 
 # To upgrade the proxy via L1 council
-# Use forge cast calldata and target to the proxyAdmin address 
+# Use forge cast calldata and target to the proxyAdmin address
 
 ANVIL_DEFAULT_ACCOUNT=anvil-default-0 # cast wallet import anvil-default-0 --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
 WALLET_NAME=mainnet-actual-0
@@ -29,4 +29,4 @@ echo "executing script"
 # Add --resume when re-running after it has failed
 forge script S1_U1MX_FinalizerTaskManager.s.sol --sig "run()" --rpc-url $RPC_URL --account $WALLET_NAME --broadcast -vvvvv --verify --etherscan-api-key $ETHERSCAN_API_KEY
 
-forge script S1_U1MX_FinalizerTaskManager.s.sol --sig "verify()" --rpc-url $RPC_URL --account $WALLET_NAME -vvvvv
+# forge script S1_U1MX_FinalizerTaskManager.s.sol --sig "verify()" --rpc-url $RPC_URL --account $WALLET_NAME -vvvvv

--- a/contracts/script/upgrades-and-migrations/holesky/S1_U1MX_FinalizerTaskManager/upgrade_output.json
+++ b/contracts/script/upgrades-and-migrations/holesky/S1_U1MX_FinalizerTaskManager/upgrade_output.json
@@ -1,0 +1,10 @@
+{
+  "addresses": {
+    "taskManager": "0x2117542bae8e4084173eFD734783eA275ad232Ad",
+    "taskManagerImplementation": "0xaD96AdE588Ab4d9343b147942a601685B89d195f"
+  },
+  "chainInfo": {
+    "chainId": 17000,
+    "lastUpgradeImplDeployBlock": 3556363
+  }
+}

--- a/contracts/src/FinalizerTaskManager.sol
+++ b/contracts/src/FinalizerTaskManager.sol
@@ -70,7 +70,7 @@ contract FinalizerTaskManager is
 
     bool public isTaskPending;
 
-    mapping(IRolldown.ChainId => uint32) public chainRdBatchNonce;
+    mapping(uint8 => uint32) public chainRdBatchNonce;
 
     // TODO
     // Maybe skip storing this
@@ -291,8 +291,8 @@ contract FinalizerTaskManager is
         // TODO
         // Maybe this belongs in createNewRdTask
         require(
-            chainRdBatchNonce[taskResponse.chainId] == 0
-                || taskResponse.batchId == chainRdBatchNonce[taskResponse.chainId],
+            chainRdBatchNonce[uint8(taskResponse.chainId)] == 0
+                || taskResponse.batchId == chainRdBatchNonce[uint8(taskResponse.chainId)],
             "chainRdBatchNonce mismatch"
         );
 
@@ -336,7 +336,7 @@ contract FinalizerTaskManager is
             range.end = taskResponse.rangeEnd;
             rolldown.update_l1_from_l2(taskResponse.rdUpdate, range);
         }
-        chainRdBatchNonce[taskResponse.chainId] = taskResponse.batchId + 1;
+        chainRdBatchNonce[uint8(taskResponse.chainId)] = taskResponse.batchId + 1;
 
         lastCompletedRdTaskNum = task.taskNum;
         lastCompletedRdTaskCreatedBlock = task.taskCreatedBlock;

--- a/ferry-withdrawal/package.json
+++ b/ferry-withdrawal/package.json
@@ -28,7 +28,7 @@
     "@types/json-bigint": "^1.0.4",
     "@types/node": "20.10.3",
     "rimraf": "5.0.5",
-    "semantic-release": "^24.1.0",
+    "semantic-release": "22.0.12",
     "semantic-release-monorepo": "^8.0.2",
     "typescript": "5.4.5",
     "vitest": "^2.0.3"

--- a/ferry-withdrawal/yarn.lock
+++ b/ferry-withdrawal/yarn.lock
@@ -1020,120 +1020,137 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@octokit/auth-token@npm:^5.0.0":
-  version: 5.1.2
-  resolution: "@octokit/auth-token@npm:5.1.2"
-  checksum: 10c0/bd4952571d9c559ede1f6ef8f7756900256d19df0180db04da88886a05484c7e6a4397611422e4804465a82addc8c2daa21d0bb4f450403552ee81041a4046d1
+"@octokit/auth-token@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "@octokit/auth-token@npm:4.0.0"
+  checksum: 10c0/57acaa6c394c5abab2f74e8e1dcf4e7a16b236f713c77a54b8f08e2d14114de94b37946259e33ec2aab0566b26f724c2b71d2602352b59e541a9854897618f3c
   languageName: node
   linkType: hard
 
-"@octokit/core@npm:^6.0.0":
-  version: 6.1.4
-  resolution: "@octokit/core@npm:6.1.4"
+"@octokit/core@npm:^5.0.0":
+  version: 5.2.1
+  resolution: "@octokit/core@npm:5.2.1"
   dependencies:
-    "@octokit/auth-token": "npm:^5.0.0"
-    "@octokit/graphql": "npm:^8.1.2"
-    "@octokit/request": "npm:^9.2.1"
-    "@octokit/request-error": "npm:^6.1.7"
-    "@octokit/types": "npm:^13.6.2"
-    before-after-hook: "npm:^3.0.2"
-    universal-user-agent: "npm:^7.0.0"
-  checksum: 10c0/bcb05e83c54f686ae55bd3793e63a1832f83cbe804586b52c61b0e18942609dcc209af501720de6f2c87dc575047645b074f4cd5822d461e892058ea9654aebc
+    "@octokit/auth-token": "npm:^4.0.0"
+    "@octokit/graphql": "npm:^7.1.0"
+    "@octokit/request": "npm:^8.4.1"
+    "@octokit/request-error": "npm:^5.1.1"
+    "@octokit/types": "npm:^13.0.0"
+    before-after-hook: "npm:^2.2.0"
+    universal-user-agent: "npm:^6.0.0"
+  checksum: 10c0/9759c70a6a6477a636f336d717657761243bab0e9d34c4012a8b2d70aafd89ba3d24289fb7e05352999c6ec526fe572b8aff9ad59e90761842fb72fb7d59ed95
   languageName: node
   linkType: hard
 
-"@octokit/endpoint@npm:^10.1.3":
-  version: 10.1.3
-  resolution: "@octokit/endpoint@npm:10.1.3"
+"@octokit/endpoint@npm:^9.0.6":
+  version: 9.0.6
+  resolution: "@octokit/endpoint@npm:9.0.6"
   dependencies:
-    "@octokit/types": "npm:^13.6.2"
-    universal-user-agent: "npm:^7.0.2"
-  checksum: 10c0/096956534efee1f683b4749673c2d1673c6fbe5362b9cce553f9f4b956feaf59bde816594de72f4352f749b862d0b15bc0e2fa7fb0e198deb1fe637b5f4a8bc7
+    "@octokit/types": "npm:^13.1.0"
+    universal-user-agent: "npm:^6.0.0"
+  checksum: 10c0/8e06197b21869aeb498e0315093ca6fbee12bd1bdcfc1667fcd7d79d827d84f2c5a30702ffd28bba7879780e367d14c30df5b20d47fcaed5de5fdc05f5d4e013
   languageName: node
   linkType: hard
 
-"@octokit/graphql@npm:^8.1.2":
-  version: 8.2.1
-  resolution: "@octokit/graphql@npm:8.2.1"
+"@octokit/graphql@npm:^7.1.0":
+  version: 7.1.1
+  resolution: "@octokit/graphql@npm:7.1.1"
   dependencies:
-    "@octokit/request": "npm:^9.2.2"
-    "@octokit/types": "npm:^13.8.0"
-    universal-user-agent: "npm:^7.0.0"
-  checksum: 10c0/79fe7b50113bef90a32e3b6ee48923cad2afc049aba5c22e44167cf5773e2688a4e953f3ee1e24bee9706ccf7588ae14451933b282f63f1f7d5c95d319df23dd
+    "@octokit/request": "npm:^8.4.1"
+    "@octokit/types": "npm:^13.0.0"
+    universal-user-agent: "npm:^6.0.0"
+  checksum: 10c0/c27216200f3f4ce7ce2a694fb7ea43f8ea4a807fbee3a423c41ed137dd7948dfc0bbf6ea1656f029a7625c84b583acdef740a7032266d0eff55305c91c3a1ed6
   languageName: node
   linkType: hard
 
-"@octokit/openapi-types@npm:^23.0.1":
-  version: 23.0.1
-  resolution: "@octokit/openapi-types@npm:23.0.1"
-  checksum: 10c0/ab734ceb26343d9f051a59503b8cb5bdc7fec9ca044b60511b227179bec73141dd9144a6b2d68bcd737741881b136c1b7d5392da89ae2e35e39acc489e5eb4c1
+"@octokit/openapi-types@npm:^20.0.0":
+  version: 20.0.0
+  resolution: "@octokit/openapi-types@npm:20.0.0"
+  checksum: 10c0/5176dcc3b9d182ede3d446750cfa5cf31139624785a73fcf3511e3102a802b4d7cc45e999c27ed91d73fe8b7d718c8c406facb48688926921a71fe603b7db95d
   languageName: node
   linkType: hard
 
-"@octokit/plugin-paginate-rest@npm:^11.0.0":
-  version: 11.4.3
-  resolution: "@octokit/plugin-paginate-rest@npm:11.4.3"
-  dependencies:
-    "@octokit/types": "npm:^13.7.0"
-  peerDependencies:
-    "@octokit/core": ">=6"
-  checksum: 10c0/132fa9c4eacec84d8025866775f0325a752a4c7496a61ebafbd72c80626ead44d1efdae738f1dffd70e2bf3a34e007693ea2356fca5c2a1be445ac466231c395
+"@octokit/openapi-types@npm:^24.2.0":
+  version: 24.2.0
+  resolution: "@octokit/openapi-types@npm:24.2.0"
+  checksum: 10c0/8f47918b35e9b7f6109be6f7c8fc3a64ad13a48233112b29e92559e64a564b810eb3ebf81b4cd0af1bb2989d27b9b95cca96e841ec4e23a3f68703cefe62fd9e
   languageName: node
   linkType: hard
 
-"@octokit/plugin-retry@npm:^7.0.0":
-  version: 7.1.4
-  resolution: "@octokit/plugin-retry@npm:7.1.4"
-  dependencies:
-    "@octokit/request-error": "npm:^6.1.7"
-    "@octokit/types": "npm:^13.6.2"
-    bottleneck: "npm:^2.15.3"
-  peerDependencies:
-    "@octokit/core": ">=6"
-  checksum: 10c0/c38041920afa14c00b0b42ba6c77da45ed5deb47dc843497061193c2b28cf14ab2b928f962fcdf14c9a97c78490732c9619d77392c3e8ffa4932e80de18fa701
-  languageName: node
-  linkType: hard
-
-"@octokit/plugin-throttling@npm:^9.0.0":
-  version: 9.4.0
-  resolution: "@octokit/plugin-throttling@npm:9.4.0"
-  dependencies:
-    "@octokit/types": "npm:^13.7.0"
-    bottleneck: "npm:^2.15.3"
-  peerDependencies:
-    "@octokit/core": ^6.1.3
-  checksum: 10c0/0d633cc1fa762306a06dacefc37662136c2676ee61fb2f8a0ef9cd18f9e11ff28d96d0746a236a68702534d91ded92928bf29aaf40b4ddaa44954e0474cc92de
-  languageName: node
-  linkType: hard
-
-"@octokit/request-error@npm:^6.1.7":
-  version: 6.1.7
-  resolution: "@octokit/request-error@npm:6.1.7"
-  dependencies:
-    "@octokit/types": "npm:^13.6.2"
-  checksum: 10c0/24bd6f98b1d7b2d4062de34777b4195d3cc4dc40c3187a0321dd588291ec5e13b5760765aacdef3a73796a529d3dec0bfb820780be6ef526a3e774d13566b5b0
-  languageName: node
-  linkType: hard
-
-"@octokit/request@npm:^9.2.1, @octokit/request@npm:^9.2.2":
+"@octokit/plugin-paginate-rest@npm:^9.0.0":
   version: 9.2.2
-  resolution: "@octokit/request@npm:9.2.2"
+  resolution: "@octokit/plugin-paginate-rest@npm:9.2.2"
   dependencies:
-    "@octokit/endpoint": "npm:^10.1.3"
-    "@octokit/request-error": "npm:^6.1.7"
-    "@octokit/types": "npm:^13.6.2"
-    fast-content-type-parse: "npm:^2.0.0"
-    universal-user-agent: "npm:^7.0.2"
-  checksum: 10c0/14cb523c17ed619c63e52025af9fdc67357b63d113905ec0ccb47badd20926e6f37a17a0620d3a906823b496e3b7efb29ed1e2af658cde5daf3ed3f88b421973
+    "@octokit/types": "npm:^12.6.0"
+  peerDependencies:
+    "@octokit/core": 5
+  checksum: 10c0/e9c85b17064fe6b62f9af88dba008f3daef456b1195340ea0831990e9c4dbabe89be950b6e5dc924ebcca18ad1aaa0cf6df7d824dc8be26ce9a55f20336ff815
   languageName: node
   linkType: hard
 
-"@octokit/types@npm:^13.6.2, @octokit/types@npm:^13.7.0, @octokit/types@npm:^13.8.0":
-  version: 13.8.0
-  resolution: "@octokit/types@npm:13.8.0"
+"@octokit/plugin-retry@npm:^6.0.0":
+  version: 6.1.0
+  resolution: "@octokit/plugin-retry@npm:6.1.0"
   dependencies:
-    "@octokit/openapi-types": "npm:^23.0.1"
-  checksum: 10c0/e08c2fcf10e374f18e4c9fa12a6ada33a40f112d1209012a39f0ce40ae7aa9dcf0598b6007b467f63cc4a97e7b1388d6eed34ddef61494655e08b5a95afaad97
+    "@octokit/request-error": "npm:^5.0.0"
+    "@octokit/types": "npm:^13.0.0"
+    bottleneck: "npm:^2.15.3"
+  peerDependencies:
+    "@octokit/core": 5
+  checksum: 10c0/ae8053b317ad462f649a9a1e56d3705d26a99ad0d427c8d9af7775f803cf326791a51c8b8dc5474111e582b0a2e1ecf1aad5e83a3061306fdb4cc1451a6056c5
+  languageName: node
+  linkType: hard
+
+"@octokit/plugin-throttling@npm:^8.0.0":
+  version: 8.2.0
+  resolution: "@octokit/plugin-throttling@npm:8.2.0"
+  dependencies:
+    "@octokit/types": "npm:^12.2.0"
+    bottleneck: "npm:^2.15.3"
+  peerDependencies:
+    "@octokit/core": ^5.0.0
+  checksum: 10c0/e65de9958ac5f29ba473bb969d25738f7466dad1b64e8181199c71438c06a6333ba655bd5194581a24199ca06fc9a6e752d0a4782b554ef603b0acffe9f8bfbd
+  languageName: node
+  linkType: hard
+
+"@octokit/request-error@npm:^5.0.0, @octokit/request-error@npm:^5.1.1":
+  version: 5.1.1
+  resolution: "@octokit/request-error@npm:5.1.1"
+  dependencies:
+    "@octokit/types": "npm:^13.1.0"
+    deprecation: "npm:^2.0.0"
+    once: "npm:^1.4.0"
+  checksum: 10c0/dc9fc76ea5e4199273e4665ce9ddf345fe8f25578d9999c9a16f276298e61ee6fe0e6f5a6147b91ba3b34fdf5b9e6b7af6ae13d6333175e95b30c574088f7a2d
+  languageName: node
+  linkType: hard
+
+"@octokit/request@npm:^8.4.1":
+  version: 8.4.1
+  resolution: "@octokit/request@npm:8.4.1"
+  dependencies:
+    "@octokit/endpoint": "npm:^9.0.6"
+    "@octokit/request-error": "npm:^5.1.1"
+    "@octokit/types": "npm:^13.1.0"
+    universal-user-agent: "npm:^6.0.0"
+  checksum: 10c0/1a69dcb7336de708a296db9e9a58040e5b284a87495a63112f80eb0007da3fc96a9fadecb9e875fc63cf179c23a0f81031fbef2a6f610a219e45805ead03fcf3
+  languageName: node
+  linkType: hard
+
+"@octokit/types@npm:^12.2.0, @octokit/types@npm:^12.6.0":
+  version: 12.6.0
+  resolution: "@octokit/types@npm:12.6.0"
+  dependencies:
+    "@octokit/openapi-types": "npm:^20.0.0"
+  checksum: 10c0/0bea58bda46c93287f5a80a0e52bc60e7dc7136b8a38c3569d63d073fb9df4a56acdb9d9bdba9978f37c374a4a6e3e52886ef5b08cace048adb0012cacef942c
+  languageName: node
+  linkType: hard
+
+"@octokit/types@npm:^13.0.0, @octokit/types@npm:^13.1.0":
+  version: 13.10.0
+  resolution: "@octokit/types@npm:13.10.0"
+  dependencies:
+    "@octokit/openapi-types": "npm:^24.2.0"
+  checksum: 10c0/f66a401b89d653ec28e5c1529abdb7965752db4d9d40fa54c80e900af4c6bf944af6bd0a83f5b4f1eecb72e3d646899dfb27ffcf272ac243552de7e3b97a038d
   languageName: node
   linkType: hard
 
@@ -1896,21 +1913,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@semantic-release/commit-analyzer@npm:^13.0.0-beta.1":
-  version: 13.0.1
-  resolution: "@semantic-release/commit-analyzer@npm:13.0.1"
+"@semantic-release/commit-analyzer@npm:^11.0.0":
+  version: 11.1.0
+  resolution: "@semantic-release/commit-analyzer@npm:11.1.0"
   dependencies:
-    conventional-changelog-angular: "npm:^8.0.0"
-    conventional-changelog-writer: "npm:^8.0.0"
-    conventional-commits-filter: "npm:^5.0.0"
-    conventional-commits-parser: "npm:^6.0.0"
+    conventional-changelog-angular: "npm:^7.0.0"
+    conventional-commits-filter: "npm:^4.0.0"
+    conventional-commits-parser: "npm:^5.0.0"
     debug: "npm:^4.0.0"
-    import-from-esm: "npm:^2.0.0"
+    import-from-esm: "npm:^1.0.3"
     lodash-es: "npm:^4.17.21"
     micromatch: "npm:^4.0.2"
   peerDependencies:
     semantic-release: ">=20.1.0"
-  checksum: 10c0/5b8f2a083c1de71b19ee795e45bfa07da08a047a62062df7128fb8a1b885c8137ad8502e75b7f788b7cdb631ac3f4da7a9c4f66b7c622065e4d20a292e4c08ab
+  checksum: 10c0/f39dd42a69ee2afd13b690489c5d266802041e47b09e36ca7534bb1a4a0069295d51c43f2a180a36369ff9b38c31ef9a4d6ca39c823768279761304f0f5dd7e3
   languageName: node
   linkType: hard
 
@@ -1962,14 +1978,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@semantic-release/github@npm:^11.0.0":
-  version: 11.0.1
-  resolution: "@semantic-release/github@npm:11.0.1"
+"@semantic-release/github@npm:^9.0.0":
+  version: 9.2.6
+  resolution: "@semantic-release/github@npm:9.2.6"
   dependencies:
-    "@octokit/core": "npm:^6.0.0"
-    "@octokit/plugin-paginate-rest": "npm:^11.0.0"
-    "@octokit/plugin-retry": "npm:^7.0.0"
-    "@octokit/plugin-throttling": "npm:^9.0.0"
+    "@octokit/core": "npm:^5.0.0"
+    "@octokit/plugin-paginate-rest": "npm:^9.0.0"
+    "@octokit/plugin-retry": "npm:^6.0.0"
+    "@octokit/plugin-throttling": "npm:^8.0.0"
     "@semantic-release/error": "npm:^4.0.0"
     aggregate-error: "npm:^5.0.0"
     debug: "npm:^4.3.4"
@@ -1977,24 +1993,24 @@ __metadata:
     globby: "npm:^14.0.0"
     http-proxy-agent: "npm:^7.0.0"
     https-proxy-agent: "npm:^7.0.0"
-    issue-parser: "npm:^7.0.0"
+    issue-parser: "npm:^6.0.0"
     lodash-es: "npm:^4.17.21"
     mime: "npm:^4.0.0"
     p-filter: "npm:^4.0.0"
     url-join: "npm:^5.0.0"
   peerDependencies:
-    semantic-release: ">=24.1.0"
-  checksum: 10c0/6bcac6f20e6326ddae5085bee1963b5d3fc6571b163e8d31d0485260e51472d2d1a695b6bc4042dcaa1de45c81d0d0c2f82d6cb614abe78af0a6374ef891f76b
+    semantic-release: ">=20.1.0"
+  checksum: 10c0/1fd4777d70139c4bf05b59c8585f42df0900f1d257ca532992b317e3876df0855443b65edd9eb8cb9f08affad8a08503c7e616a712507b8310ec5c6aa47c23f7
   languageName: node
   linkType: hard
 
-"@semantic-release/npm@npm:^12.0.0":
-  version: 12.0.1
-  resolution: "@semantic-release/npm@npm:12.0.1"
+"@semantic-release/npm@npm:^11.0.0":
+  version: 11.0.3
+  resolution: "@semantic-release/npm@npm:11.0.3"
   dependencies:
     "@semantic-release/error": "npm:^4.0.0"
     aggregate-error: "npm:^5.0.0"
-    execa: "npm:^9.0.0"
+    execa: "npm:^8.0.0"
     fs-extra: "npm:^11.0.0"
     lodash-es: "npm:^4.17.21"
     nerf-dart: "npm:^1.0.0"
@@ -2007,27 +2023,27 @@ __metadata:
     tempy: "npm:^3.0.0"
   peerDependencies:
     semantic-release: ">=20.1.0"
-  checksum: 10c0/816d2ed41bd7ef1191c7094ac95c3a9b5b0fc7d58808d0f55d6d8c109e548480032938bd3508295cb7c869ba66f29c3a5976b4ebfd3408f71f999d1b2c66e1a0
+  checksum: 10c0/142f396de87ceb42d917b598cb7889b68e3f09b0a97736de8cf7ee48879714bb66efed10520a7a20699493c58b5523ed2925089cd5b59642b045e458101ef13c
   languageName: node
   linkType: hard
 
-"@semantic-release/release-notes-generator@npm:^14.0.0-beta.1":
-  version: 14.0.3
-  resolution: "@semantic-release/release-notes-generator@npm:14.0.3"
+"@semantic-release/release-notes-generator@npm:^12.0.0":
+  version: 12.1.0
+  resolution: "@semantic-release/release-notes-generator@npm:12.1.0"
   dependencies:
-    conventional-changelog-angular: "npm:^8.0.0"
-    conventional-changelog-writer: "npm:^8.0.0"
-    conventional-commits-filter: "npm:^5.0.0"
-    conventional-commits-parser: "npm:^6.0.0"
+    conventional-changelog-angular: "npm:^7.0.0"
+    conventional-changelog-writer: "npm:^7.0.0"
+    conventional-commits-filter: "npm:^4.0.0"
+    conventional-commits-parser: "npm:^5.0.0"
     debug: "npm:^4.0.0"
     get-stream: "npm:^7.0.0"
-    import-from-esm: "npm:^2.0.0"
+    import-from-esm: "npm:^1.0.3"
     into-stream: "npm:^7.0.0"
     lodash-es: "npm:^4.17.21"
-    read-package-up: "npm:^11.0.0"
+    read-pkg-up: "npm:^11.0.0"
   peerDependencies:
     semantic-release: ">=20.1.0"
-  checksum: 10c0/dfe221b8dc05e7f4e8d04c9e37accde1822d0f9e7608d83b0c67ad296cf7218c2f08b2afaf23f4b9d5fbeefb52a9e5bb7842dfb55960b4ee56c74b86cad3e201
+  checksum: 10c0/29dee44ee90e6396386ac5187a1e23cd44ad64b7440348ea4e18c7440199007aa7a7d8f158cc773ea142288b2c212b666b77d57b769224e9e7cdcb2ef8978555
   languageName: node
   linkType: hard
 
@@ -2797,6 +2813,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"JSONStream@npm:^1.3.5":
+  version: 1.3.5
+  resolution: "JSONStream@npm:1.3.5"
+  dependencies:
+    jsonparse: "npm:^1.2.0"
+    through: "npm:>=2.2.7 <3"
+  bin:
+    JSONStream: ./bin.js
+  checksum: 10c0/0f54694da32224d57b715385d4a6b668d2117379d1f3223dc758459246cca58fdc4c628b83e8a8883334e454a0a30aa198ede77c788b55537c1844f686a751f2
+  languageName: node
+  linkType: hard
+
 "abbrev@npm:^3.0.0":
   version: 3.0.0
   resolution: "abbrev@npm:3.0.0"
@@ -2865,12 +2893,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-escapes@npm:^7.0.0":
-  version: 7.0.0
-  resolution: "ansi-escapes@npm:7.0.0"
-  dependencies:
-    environment: "npm:^1.0.0"
-  checksum: 10c0/86e51e36fabef18c9c004af0a280573e828900641cea35134a124d2715e0c5a473494ab4ce396614505da77638ae290ff72dd8002d9747d2ee53f5d6bbe336be
+"ansi-escapes@npm:^6.2.0":
+  version: 6.2.1
+  resolution: "ansi-escapes@npm:6.2.1"
+  checksum: 10c0/a2c6f58b044be5f69662ee17073229b492daa2425a7fd99a665db6c22eab6e4ab42752807def7281c1c7acfed48f87f2362dda892f08c2c437f1b39c6b033103
   languageName: node
   linkType: hard
 
@@ -2881,7 +2907,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-regex@npm:^6.0.1, ansi-regex@npm:^6.1.0":
+"ansi-regex@npm:^6.0.1":
   version: 6.1.0
   resolution: "ansi-regex@npm:6.1.0"
   checksum: 10c0/a91daeddd54746338478eef88af3439a7edf30f8e23196e2d6ed182da9add559c601266dbef01c2efa46a958ad6f1f8b176799657616c702b5b02e799e7fd8dc
@@ -2897,7 +2923,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-styles@npm:^4.0.0, ansi-styles@npm:^4.1.0":
+"ansi-styles@npm:^4.0.0":
   version: 4.3.0
   resolution: "ansi-styles@npm:4.3.0"
   dependencies:
@@ -2913,10 +2939,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"any-promise@npm:^1.0.0":
-  version: 1.3.0
-  resolution: "any-promise@npm:1.3.0"
-  checksum: 10c0/60f0298ed34c74fef50daab88e8dab786036ed5a7fad02e012ab57e376e0a0b4b29e83b95ea9b5e7d89df762f5f25119b83e00706ecaccb22cfbacee98d74889
+"ansicolors@npm:~0.3.2":
+  version: 0.3.2
+  resolution: "ansicolors@npm:0.3.2"
+  checksum: 10c0/e202182895e959c5357db6c60791b2abaade99fcc02221da11a581b26a7f83dc084392bc74e4d3875c22f37b3c9ef48842e896e3bfed394ec278194b8003e0ac
   languageName: node
   linkType: hard
 
@@ -3057,10 +3083,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"before-after-hook@npm:^3.0.2":
-  version: 3.0.2
-  resolution: "before-after-hook@npm:3.0.2"
-  checksum: 10c0/dea640f9e88a1085372c9bcc974b7bf379267490693da92ec102a7d8b515dd1e95f00ef575a146b83ca638104c57406c3427d37bdf082f602dde4b56d05bba14
+"before-after-hook@npm:^2.2.0":
+  version: 2.2.3
+  resolution: "before-after-hook@npm:2.2.3"
+  checksum: 10c0/0488c4ae12df758ca9d49b3bb27b47fd559677965c52cae7b335784724fb8bf96c42b6e5ba7d7afcbc31facb0e294c3ef717cc41c5bc2f7bd9e76f8b90acd31c
   languageName: node
   linkType: hard
 
@@ -3297,6 +3323,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cardinal@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "cardinal@npm:2.1.1"
+  dependencies:
+    ansicolors: "npm:~0.3.2"
+    redeyed: "npm:~2.1.0"
+  bin:
+    cdl: ./bin/cdl.js
+  checksum: 10c0/0051d0e64c0e1dff480c1aace4c018c48ecca44030533257af3f023107ccdeb061925603af6d73710f0345b0ae0eb57e5241d181d9b5fdb595d45c5418161675
+  languageName: node
+  linkType: hard
+
 "cbw-sdk@npm:@coinbase/wallet-sdk@3.9.3":
   version: 3.9.3
   resolution: "@coinbase/wallet-sdk@npm:3.9.3"
@@ -3338,17 +3376,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^4.0.0":
-  version: 4.1.2
-  resolution: "chalk@npm:4.1.2"
-  dependencies:
-    ansi-styles: "npm:^4.1.0"
-    supports-color: "npm:^7.1.0"
-  checksum: 10c0/4a3fef5cc34975c898ffe77141450f679721df9dde00f6c304353fa9c8b571929123b26a0e4617bde5018977eb655b31970c297b91b63ee83bb82aeb04666880
-  languageName: node
-  linkType: hard
-
-"chalk@npm:^5.3.0, chalk@npm:^5.4.1":
+"chalk@npm:^5.3.0":
   version: 5.4.1
   resolution: "chalk@npm:5.4.1"
   checksum: 10c0/b23e88132c702f4855ca6d25cb5538b1114343e41472d5263ee8a37cccfccd9c4216d111e1097c6a27830407a1dc81fecdf2a56f2c63033d4dbbd88c10b0dcef
@@ -3434,23 +3462,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cli-highlight@npm:^2.1.11":
-  version: 2.1.11
-  resolution: "cli-highlight@npm:2.1.11"
-  dependencies:
-    chalk: "npm:^4.0.0"
-    highlight.js: "npm:^10.7.1"
-    mz: "npm:^2.4.0"
-    parse5: "npm:^5.1.1"
-    parse5-htmlparser2-tree-adapter: "npm:^6.0.0"
-    yargs: "npm:^16.0.0"
-  bin:
-    highlight: bin/highlight
-  checksum: 10c0/b5b4af3b968aa9df77eee449a400fbb659cf47c4b03a395370bd98d5554a00afaa5819b41a9a8a1ca0d37b0b896a94e57c65289b37359a25b700b1f56eb04852
-  languageName: node
-  linkType: hard
-
-"cli-table3@npm:^0.6.5":
+"cli-table3@npm:^0.6.3":
   version: 0.6.5
   resolution: "cli-table3@npm:0.6.5"
   dependencies:
@@ -3471,17 +3483,6 @@ __metadata:
     strip-ansi: "npm:^6.0.0"
     wrap-ansi: "npm:^6.2.0"
   checksum: 10c0/35229b1bb48647e882104cac374c9a18e34bbf0bace0e2cf03000326b6ca3050d6b59545d91e17bfe3705f4a0e2988787aa5cde6331bf5cbbf0164732cef6492
-  languageName: node
-  linkType: hard
-
-"cliui@npm:^7.0.2":
-  version: 7.0.4
-  resolution: "cliui@npm:7.0.4"
-  dependencies:
-    string-width: "npm:^4.2.0"
-    strip-ansi: "npm:^6.0.0"
-    wrap-ansi: "npm:^7.0.0"
-  checksum: 10c0/6035f5daf7383470cef82b3d3db00bec70afb3423538c50394386ffbbab135e26c3689c41791f911fa71b62d13d3863c712fdd70f0fbdffd938a1e6fd09aac00
   languageName: node
   linkType: hard
 
@@ -3631,51 +3632,49 @@ __metadata:
   languageName: node
   linkType: hard
 
-"conventional-changelog-angular@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "conventional-changelog-angular@npm:8.0.0"
+"conventional-changelog-angular@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "conventional-changelog-angular@npm:7.0.0"
   dependencies:
     compare-func: "npm:^2.0.0"
-  checksum: 10c0/743faceab876bb9b9656f2389830d0ccb7c5caf02a629cb495d75c65c43414274728d7059b716d0c7d66fd663f8b978f25d44657148b8bc64ece12952cbfd886
+  checksum: 10c0/90e73e25e224059b02951b6703b5f8742dc2a82c1fea62163978e6735fd3ab04350897a8fc6f443ec6b672d6b66e28a0820e833e544a0101f38879e5e6289b7e
   languageName: node
   linkType: hard
 
-"conventional-changelog-writer@npm:^8.0.0":
-  version: 8.0.1
-  resolution: "conventional-changelog-writer@npm:8.0.1"
+"conventional-changelog-writer@npm:^7.0.0":
+  version: 7.0.1
+  resolution: "conventional-changelog-writer@npm:7.0.1"
   dependencies:
-    conventional-commits-filter: "npm:^5.0.0"
+    conventional-commits-filter: "npm:^4.0.0"
     handlebars: "npm:^4.7.7"
-    meow: "npm:^13.0.0"
+    json-stringify-safe: "npm:^5.0.1"
+    meow: "npm:^12.0.1"
     semver: "npm:^7.5.2"
+    split2: "npm:^4.0.0"
   bin:
-    conventional-changelog-writer: dist/cli/index.js
-  checksum: 10c0/2cd1904f9dc37d1b1ad336fbab3bda8da2f939776adf8acb1bc056c3f7138b925f54bc7ec6bde02a7ac142c9f7e64792eb91a04ab9a22266e286bfc90326c28a
+    conventional-changelog-writer: cli.mjs
+  checksum: 10c0/ec51708c33860777f2b85f1df588aed918cab08919146cdfac8f271e31c0caee22c5c50df78e4ce358022e58f65c8de77fd6a5fb529f4bb5ba27c2d1e072750f
   languageName: node
   linkType: hard
 
-"conventional-commits-filter@npm:^5.0.0":
+"conventional-commits-filter@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "conventional-commits-filter@npm:4.0.0"
+  checksum: 10c0/b26ea11ebb38218cb3cbbaf7d68b0f7c3b0eb7ad69afe9c9431d91e784acbebaeda7a095127ae5a7f8b75087d62b44e8e69d63426ff02b49f7dd504755934247
+  languageName: node
+  linkType: hard
+
+"conventional-commits-parser@npm:^5.0.0":
   version: 5.0.0
-  resolution: "conventional-commits-filter@npm:5.0.0"
-  checksum: 10c0/678900d6c589bbe1739929071ea0ca89c872b9f3cc6974994726eb7a197ca04243e9ea65cae39a55e41fdc20f27fdfc43060588750d828e0efab41f309a42934
-  languageName: node
-  linkType: hard
-
-"conventional-commits-parser@npm:^6.0.0":
-  version: 6.1.0
-  resolution: "conventional-commits-parser@npm:6.1.0"
+  resolution: "conventional-commits-parser@npm:5.0.0"
   dependencies:
-    meow: "npm:^13.0.0"
+    JSONStream: "npm:^1.3.5"
+    is-text-path: "npm:^2.0.0"
+    meow: "npm:^12.0.1"
+    split2: "npm:^4.0.0"
   bin:
-    conventional-commits-parser: dist/cli/index.js
-  checksum: 10c0/df68b04a9b52908c47b2aa7fe07c21d295998729e075ef9f949f3ca18245ea031e59c42ace730563163c99db4dc3ce9062e26d9a7234dd7403074acd74605b2e
-  languageName: node
-  linkType: hard
-
-"convert-hrtime@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "convert-hrtime@npm:5.0.0"
-  checksum: 10c0/2092e51aab205e1141440e84e2a89f8881e68e47c1f8bc168dfd7c67047d8f1db43bac28044bc05749205651fead4e7910f52c7bb6066213480df99e333e9f47
+    conventional-commits-parser: cli.mjs
+  checksum: 10c0/c9e542f4884119a96a6bf3311ff62cdee55762d8547f4c745ae3ebdc50afe4ba7691e165e34827d5cf63283cbd93ab69917afd7922423075b123d5d9a7a82ed2
   languageName: node
   linkType: hard
 
@@ -3707,20 +3706,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cosmiconfig@npm:^9.0.0":
-  version: 9.0.0
-  resolution: "cosmiconfig@npm:9.0.0"
+"cosmiconfig@npm:^8.0.0":
+  version: 8.3.6
+  resolution: "cosmiconfig@npm:8.3.6"
   dependencies:
-    env-paths: "npm:^2.2.1"
     import-fresh: "npm:^3.3.0"
     js-yaml: "npm:^4.1.0"
     parse-json: "npm:^5.2.0"
+    path-type: "npm:^4.0.0"
   peerDependencies:
     typescript: ">=4.9.5"
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10c0/1c1703be4f02a250b1d6ca3267e408ce16abfe8364193891afc94c2d5c060b69611fdc8d97af74b7e6d5d1aac0ab2fb94d6b079573146bc2d756c2484ce5f0ee
+  checksum: 10c0/0382a9ed13208f8bfc22ca2f62b364855207dffdb73dc26e150ade78c3093f1cf56172df2dd460c8caf2afa91c0ed4ec8a88c62f8f9cd1cf423d26506aa8797a
   languageName: node
   linkType: hard
 
@@ -3918,6 +3917,13 @@ __metadata:
   version: 2.0.0
   resolution: "depd@npm:2.0.0"
   checksum: 10c0/58bd06ec20e19529b06f7ad07ddab60e504d9e0faca4bd23079fac2d279c3594334d736508dc350e06e510aba5e22e4594483b3a6562ce7c17dd797f4cc4ad2c
+  languageName: node
+  linkType: hard
+
+"deprecation@npm:^2.0.0":
+  version: 2.3.1
+  resolution: "deprecation@npm:2.3.1"
+  checksum: 10c0/23d688ba66b74d09b908c40a76179418acbeeb0bfdf218c8075c58ad8d0c315130cb91aa3dffb623aa3a411a3569ce56c6460de6c8d69071c17fe6dd2442f032
   languageName: node
   linkType: hard
 
@@ -4141,27 +4147,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"env-ci@npm:^11.0.0":
-  version: 11.1.0
-  resolution: "env-ci@npm:11.1.0"
+"env-ci@npm:^10.0.0":
+  version: 10.0.0
+  resolution: "env-ci@npm:10.0.0"
   dependencies:
     execa: "npm:^8.0.0"
     java-properties: "npm:^1.0.2"
-  checksum: 10c0/14f0a597c1fe9ab5585532c01759db62f4c553277b33137d33cb71cdd621833184f182dc67408750973c9f884f5a0d5103fad4f873aabd9e6c4baf65f88bc22a
+  checksum: 10c0/cce92181b8cf269070c4be447784b806f0c9d380469c8c1ee97bbaebe9dd7b2e3a45377ae51b0ac00c732175378ddfb390de50fe44ae6a797415b137ae22522d
   languageName: node
   linkType: hard
 
-"env-paths@npm:^2.2.0, env-paths@npm:^2.2.1":
+"env-paths@npm:^2.2.0":
   version: 2.2.1
   resolution: "env-paths@npm:2.2.1"
   checksum: 10c0/285325677bf00e30845e330eec32894f5105529db97496ee3f598478e50f008c5352a41a30e5e72ec9de8a542b5a570b85699cd63bd2bc646dbcb9f311d83bc4
-  languageName: node
-  linkType: hard
-
-"environment@npm:^1.0.0":
-  version: 1.1.0
-  resolution: "environment@npm:1.1.0"
-  checksum: 10c0/fb26434b0b581ab397039e51ff3c92b34924a98b2039dcb47e41b7bca577b9dbf134a8eadb364415c74464b682e2d3afe1a4c0eb9873dc44ea814c5d3103331d
   languageName: node
   linkType: hard
 
@@ -4340,6 +4339,16 @@ __metadata:
   version: 1.0.5
   resolution: "escape-string-regexp@npm:1.0.5"
   checksum: 10c0/a968ad453dd0c2724e14a4f20e177aaf32bb384ab41b674a8454afe9a41c5e6fe8903323e0a1052f56289d04bd600f81278edf140b0fcc02f5cac98d0f5b5371
+  languageName: node
+  linkType: hard
+
+"esprima@npm:~4.0.0":
+  version: 4.0.1
+  resolution: "esprima@npm:4.0.1"
+  bin:
+    esparse: ./bin/esparse.js
+    esvalidate: ./bin/esvalidate.js
+  checksum: 10c0/ad4bab9ead0808cf56501750fd9d3fb276f6b105f987707d059005d57e182d18a7c9ec7f3a01794ebddcca676773e42ca48a32d67a250c9d35e009ca613caba3
   languageName: node
   linkType: hard
 
@@ -4561,13 +4570,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-content-type-parse@npm:^2.0.0":
-  version: 2.0.1
-  resolution: "fast-content-type-parse@npm:2.0.1"
-  checksum: 10c0/e5ff87d75a35ae4cf377df1dca46ec49e7abbdc8513689676ecdef548b94900b50e66e516e64470035d79b9f7010ef15d98c24d8ae803a881363cc59e0715e19
-  languageName: node
-  linkType: hard
-
 "fast-deep-equal@npm:^3.1.3":
   version: 3.1.3
   resolution: "fast-deep-equal@npm:3.1.3"
@@ -4647,7 +4649,7 @@ __metadata:
     json-bigint: "npm:^1.0.0"
     prom-client: "npm:^15.1.3"
     rimraf: "npm:5.0.5"
-    semantic-release: "npm:^24.1.0"
+    semantic-release: "npm:22.0.12"
     semantic-release-monorepo: "npm:^8.0.2"
     typescript: "npm:5.4.5"
     viem: "npm:^2.23.12"
@@ -4758,13 +4760,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"find-versions@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "find-versions@npm:6.0.0"
+"find-versions@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "find-versions@npm:5.1.0"
   dependencies:
     semver-regex: "npm:^4.0.5"
-    super-regex: "npm:^1.0.0"
-  checksum: 10c0/1e38da3058f389c8657cd6f47fbcf12412051e7d2d14017594b8ca54ec239d19058f2d9dde80f27415726ab62822e32e3ed0a81141cfc206a3b8c8f0d87a5732
+  checksum: 10c0/f1ef79d0850e0bd1eba03def02892d31feccdef75129c14b2a2d1cec563e2c51ad5a01f6a7a2d59ddbf9ecca1014ff8a6353ff2e2885e004f7a81ab1488899d4
   languageName: node
   linkType: hard
 
@@ -4919,13 +4920,6 @@ __metadata:
   version: 1.1.2
   resolution: "function-bind@npm:1.1.2"
   checksum: 10c0/d8680ee1e5fcd4c197e4ac33b2b4dce03c71f4d91717292785703db200f5c21f977c568d28061226f9b5900cbcd2c84463646134fd5337e7925e0942bc3f46d5
-  languageName: node
-  linkType: hard
-
-"function-timeout@npm:^1.0.1":
-  version: 1.0.2
-  resolution: "function-timeout@npm:1.0.2"
-  checksum: 10c0/75d7ac6c83c450b84face2c9d22307b00e10c7376aa3a34c7be260853582c5e4c502904e2f6bf1d4500c4052e748e001388f6bbd9d34ebfdfb6c4fec2169d0ff
   languageName: node
   linkType: hard
 
@@ -5231,13 +5225,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"highlight.js@npm:^10.7.1":
-  version: 10.7.3
-  resolution: "highlight.js@npm:10.7.3"
-  checksum: 10c0/073837eaf816922427a9005c56c42ad8786473dc042332dfe7901aa065e92bc3d94ebf704975257526482066abb2c8677cc0326559bb8621e046c21c5991c434
-  languageName: node
-  linkType: hard
-
 "hmac-drbg@npm:^1.0.1":
   version: 1.0.1
   resolution: "hmac-drbg@npm:1.0.1"
@@ -5414,13 +5401,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"import-from-esm@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "import-from-esm@npm:2.0.0"
+"import-from-esm@npm:^1.0.3, import-from-esm@npm:^1.3.1":
+  version: 1.3.4
+  resolution: "import-from-esm@npm:1.3.4"
   dependencies:
     debug: "npm:^4.3.4"
     import-meta-resolve: "npm:^4.0.0"
-  checksum: 10c0/6ee85521a1b540927c50f9f16c4f1fc25fa0383c16740483b5ba838d8deea8f5e7a30b6a9f6dff28292589317e679a07da8fa63890a0fd2e549a51e9d28a66fd
+  checksum: 10c0/fcd42ead421892e1d9dbc90e510f45c7d3b58887c35077cf2318e4aa39b52c07c06e2b54efd16dfe8e712421439c23794d18a5e8956cca237fc90790ed8e2241
   languageName: node
   linkType: hard
 
@@ -5698,6 +5685,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-text-path@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "is-text-path@npm:2.0.0"
+  dependencies:
+    text-extensions: "npm:^2.0.0"
+  checksum: 10c0/e3c470e1262a3a54aa0fca1c0300b2659a7aed155714be6b643f88822c03bcfa6659b491f7a05c5acd3c1a3d6d42bab47e1bdd35bcc3a25973c4f26b2928bc1a
+  languageName: node
+  linkType: hard
+
 "is-typed-array@npm:^1.1.3":
   version: 1.1.15
   resolution: "is-typed-array@npm:1.1.15"
@@ -5744,16 +5740,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"issue-parser@npm:^7.0.0":
-  version: 7.0.1
-  resolution: "issue-parser@npm:7.0.1"
+"issue-parser@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "issue-parser@npm:6.0.0"
   dependencies:
     lodash.capitalize: "npm:^4.2.1"
     lodash.escaperegexp: "npm:^4.1.2"
     lodash.isplainobject: "npm:^4.0.6"
     lodash.isstring: "npm:^4.0.1"
     lodash.uniqby: "npm:^4.7.0"
-  checksum: 10c0/1b2dad16081ae423bb96143132701e89aa8f6345ab0a10f692594ddf5699b514adccaaaf24d7c59afc977c447895bdee15fff2dfc9d6015e177f6966b06f5dcb
+  checksum: 10c0/3bfc48ca5c380061ba3db9bfb0c2a86692c74245a386d8add5eb7cd60022c85f44277692d78914ff0d37cf0da7d1743149516d00175233949c85c056d12e3b49
   languageName: node
   linkType: hard
 
@@ -5876,7 +5872,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsonparse@npm:^1.3.1":
+"jsonparse@npm:^1.2.0, jsonparse@npm:^1.3.1":
   version: 1.3.1
   resolution: "jsonparse@npm:1.3.1"
   checksum: 10c0/89bc68080cd0a0e276d4b5ab1b79cacd68f562467008d176dc23e16e97d4efec9e21741d92ba5087a8433526a45a7e6a9d5ef25408696c402ca1cfbc01a90bf0
@@ -6240,29 +6236,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"marked-terminal@npm:^7.0.0":
-  version: 7.3.0
-  resolution: "marked-terminal@npm:7.3.0"
+"marked-terminal@npm:^6.0.0":
+  version: 6.2.0
+  resolution: "marked-terminal@npm:6.2.0"
   dependencies:
-    ansi-escapes: "npm:^7.0.0"
-    ansi-regex: "npm:^6.1.0"
-    chalk: "npm:^5.4.1"
-    cli-highlight: "npm:^2.1.11"
-    cli-table3: "npm:^0.6.5"
-    node-emoji: "npm:^2.2.0"
-    supports-hyperlinks: "npm:^3.1.0"
+    ansi-escapes: "npm:^6.2.0"
+    cardinal: "npm:^2.1.1"
+    chalk: "npm:^5.3.0"
+    cli-table3: "npm:^0.6.3"
+    node-emoji: "npm:^2.1.3"
+    supports-hyperlinks: "npm:^3.0.0"
   peerDependencies:
-    marked: ">=1 <16"
-  checksum: 10c0/59d23c2ed9488c40856d828f431ae1d5d57426e791bbce8f05ec5a7d3a1f848cdb3b8d8880d76ae45570415f8b48ae459f50bbbd88ece5a31306f1e3de57f021
+    marked: ">=1 <12"
+  checksum: 10c0/72d4093cbb1ee864ced1f88fdb6fb8dbfea56d6aa3d8a1ec401ac51866ff3c32382c3f4642b19f2d808c798efde23b10300b99e3b6475b3f79e41e7741581d54
   languageName: node
   linkType: hard
 
-"marked@npm:^12.0.0":
-  version: 12.0.2
-  resolution: "marked@npm:12.0.2"
+"marked@npm:^9.0.0":
+  version: 9.1.6
+  resolution: "marked@npm:9.1.6"
   bin:
     marked: bin/marked.js
-  checksum: 10c0/45ae2e1e3f06b30a5b5f64efc6cde9830c81d1d024fd7668772a3217f1bc0f326e66a6b8970482d9783edf1f581fecac7023a7fa160f2c14dbcc16e064b4eafb
+  checksum: 10c0/010bbd33c0f38300259c5d3bf0063deb36bab098d37ac0a3be5a35a65674a4c693427fc6704f486a89f638e9b36c36b8e220a93d47163f4e70e45a1fa8ca7b60
   languageName: node
   linkType: hard
 
@@ -6280,10 +6275,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"meow@npm:^13.0.0":
-  version: 13.2.0
-  resolution: "meow@npm:13.2.0"
-  checksum: 10c0/d5b339ae314715bcd0b619dd2f8a266891928e21526b4800d49b4fba1cc3fff7e2c1ff5edd3344149fac841bc2306157f858e8c4d5eaee4d52ce52ad925664ce
+"meow@npm:^12.0.1":
+  version: 12.1.1
+  resolution: "meow@npm:12.1.1"
+  checksum: 10c0/a125ca99a32e2306e2f4cbe651a0d27f6eb67918d43a075f6e80b35e9bf372ebf0fc3a9fbc201cbbc9516444b6265fb3c9f80c5b7ebd32f548aa93eb7c28e088
   languageName: node
   linkType: hard
 
@@ -6592,17 +6587,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mz@npm:^2.4.0":
-  version: 2.7.0
-  resolution: "mz@npm:2.7.0"
-  dependencies:
-    any-promise: "npm:^1.0.0"
-    object-assign: "npm:^4.0.1"
-    thenify-all: "npm:^1.0.0"
-  checksum: 10c0/103114e93f87362f0b56ab5b2e7245051ad0276b646e3902c98397d18bb8f4a77f2ea4a2c9d3ad516034ea3a56553b60d3f5f78220001ca4c404bd711bd0af39
-  languageName: node
-  linkType: hard
-
 "nanoid@npm:^3.3.8":
   version: 3.3.10
   resolution: "nanoid@npm:3.3.10"
@@ -6667,7 +6651,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-emoji@npm:^2.2.0":
+"node-emoji@npm:^2.1.3":
   version: 2.2.0
   resolution: "node-emoji@npm:2.2.0"
   dependencies:
@@ -7021,13 +7005,6 @@ __metadata:
     once: "npm:^1.4.0"
     readable-stream: "npm:^2.3.3"
   checksum: 10c0/914e979ab40fb26cbe4309a5fc1cc6b6a428aeff17a015b9abb1197894ee67f6f02542ffd76d8e275cc40b18adc125bff6e2d6b5090932798c135100c5942007
-  languageName: node
-  linkType: hard
-
-"object-assign@npm:^4.0.1":
-  version: 4.1.1
-  resolution: "object-assign@npm:4.1.1"
-  checksum: 10c0/1f4df9945120325d041ccf7b86f31e8bcc14e73d29171e37a7903050e96b81323784ec59f93f102ec635bcf6fa8034ba3ea0a8c7e69fa202b87ae3b6cec5a414
   languageName: node
   linkType: hard
 
@@ -7387,29 +7364,6 @@ __metadata:
   version: 4.0.0
   resolution: "parse-ms@npm:4.0.0"
   checksum: 10c0/a7900f4f1ebac24cbf5e9708c16fb2fd482517fad353aecd7aefb8c2ba2f85ce017913ccb8925d231770404780df46244ea6fec598b3bde6490882358b4d2d16
-  languageName: node
-  linkType: hard
-
-"parse5-htmlparser2-tree-adapter@npm:^6.0.0":
-  version: 6.0.1
-  resolution: "parse5-htmlparser2-tree-adapter@npm:6.0.1"
-  dependencies:
-    parse5: "npm:^6.0.1"
-  checksum: 10c0/dfa5960e2aaf125707e19a4b1bc333de49232eba5a6ffffb95d313a7d6087c3b7a274b58bee8d3bd41bdf150638815d1d601a42bbf2a0345208c3c35b1279556
-  languageName: node
-  linkType: hard
-
-"parse5@npm:^5.1.1":
-  version: 5.1.1
-  resolution: "parse5@npm:5.1.1"
-  checksum: 10c0/b0f87a77a7fea5f242e3d76917c983bbea47703b9371801d51536b78942db6441cbda174bf84eb30e47315ddc6f8a0b57d68e562c790154430270acd76c1fa03
-  languageName: node
-  linkType: hard
-
-"parse5@npm:^6.0.1":
-  version: 6.0.1
-  resolution: "parse5@npm:6.0.1"
-  checksum: 10c0/595821edc094ecbcfb9ddcb46a3e1fe3a718540f8320eff08b8cf6742a5114cce2d46d45f95c26191c11b184dcaf4e2960abcd9c5ed9eb9393ac9a37efcfdecb
   languageName: node
   linkType: hard
 
@@ -7898,14 +7852,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"read-package-up@npm:^11.0.0":
+"read-pkg-up@npm:^11.0.0":
   version: 11.0.0
-  resolution: "read-package-up@npm:11.0.0"
+  resolution: "read-pkg-up@npm:11.0.0"
   dependencies:
     find-up-simple: "npm:^1.0.0"
     read-pkg: "npm:^9.0.0"
     type-fest: "npm:^4.6.0"
-  checksum: 10c0/ffee09613c2b3c3ff7e7b5e838aa01f33cba5c6dfa14f87bf6f64ed27e32678e5550e712fd7e3f3105a05c43aa774d084af04ee86d3044978edb69f30ee4505a
+  checksum: 10c0/9dfe7b1088d22804e275c235e21d64acdfb81edb73373c9ef2707aae2db8309fd35f6de90f569f0159411c25972c5a321ae6cb6a54ec01e449ce9df0a0b2397a
   languageName: node
   linkType: hard
 
@@ -7993,6 +7947,15 @@ __metadata:
   version: 0.1.0
   resolution: "real-require@npm:0.1.0"
   checksum: 10c0/c0f8ae531d1f51fe6343d47a2a1e5756e19b65a81b4a9642b9ebb4874e0d8b5f3799bc600bf4592838242477edc6f57778593f21b71d90f8ad0d8a317bbfae1c
+  languageName: node
+  linkType: hard
+
+"redeyed@npm:~2.1.0":
+  version: 2.1.1
+  resolution: "redeyed@npm:2.1.1"
+  dependencies:
+    esprima: "npm:~4.0.0"
+  checksum: 10c0/350f5e39aebab3886713a170235c38155ee64a74f0f7e629ecc0144ba33905efea30c2c3befe1fcbf0b0366e344e7bfa34e6b2502b423c9a467d32f1306ef166
   languageName: node
   linkType: hard
 
@@ -8281,34 +8244,34 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semantic-release@npm:^24.1.0":
-  version: 24.2.3
-  resolution: "semantic-release@npm:24.2.3"
+"semantic-release@npm:22.0.12":
+  version: 22.0.12
+  resolution: "semantic-release@npm:22.0.12"
   dependencies:
-    "@semantic-release/commit-analyzer": "npm:^13.0.0-beta.1"
+    "@semantic-release/commit-analyzer": "npm:^11.0.0"
     "@semantic-release/error": "npm:^4.0.0"
-    "@semantic-release/github": "npm:^11.0.0"
-    "@semantic-release/npm": "npm:^12.0.0"
-    "@semantic-release/release-notes-generator": "npm:^14.0.0-beta.1"
+    "@semantic-release/github": "npm:^9.0.0"
+    "@semantic-release/npm": "npm:^11.0.0"
+    "@semantic-release/release-notes-generator": "npm:^12.0.0"
     aggregate-error: "npm:^5.0.0"
-    cosmiconfig: "npm:^9.0.0"
+    cosmiconfig: "npm:^8.0.0"
     debug: "npm:^4.0.0"
-    env-ci: "npm:^11.0.0"
-    execa: "npm:^9.0.0"
+    env-ci: "npm:^10.0.0"
+    execa: "npm:^8.0.0"
     figures: "npm:^6.0.0"
-    find-versions: "npm:^6.0.0"
+    find-versions: "npm:^5.1.0"
     get-stream: "npm:^6.0.0"
     git-log-parser: "npm:^1.2.0"
     hook-std: "npm:^3.0.0"
-    hosted-git-info: "npm:^8.0.0"
-    import-from-esm: "npm:^2.0.0"
+    hosted-git-info: "npm:^7.0.0"
+    import-from-esm: "npm:^1.3.1"
     lodash-es: "npm:^4.17.21"
-    marked: "npm:^12.0.0"
-    marked-terminal: "npm:^7.0.0"
+    marked: "npm:^9.0.0"
+    marked-terminal: "npm:^6.0.0"
     micromatch: "npm:^4.0.2"
     p-each-series: "npm:^3.0.0"
     p-reduce: "npm:^3.0.0"
-    read-package-up: "npm:^11.0.0"
+    read-pkg-up: "npm:^11.0.0"
     resolve-from: "npm:^5.0.0"
     semver: "npm:^7.3.2"
     semver-diff: "npm:^4.0.0"
@@ -8316,7 +8279,7 @@ __metadata:
     yargs: "npm:^17.5.1"
   bin:
     semantic-release: bin/semantic-release.js
-  checksum: 10c0/75c6657429bbd31c60e2a4982a9081de0d840dce7d0910b5f93e45bf717c921847d1cbc1f1c9e40a10ae20b6b8a61e9fc6d837623832f113c05468eb15ebb8f8
+  checksum: 10c0/13e86ab9e16e32fd51b09f486ec5ea950bb541c5ea3cd4e66b0527d2a7108cfd3488510d5f29cefc83c86d279e6d5075f886bad8478c88a74cc7d5942e936722
   languageName: node
   linkType: hard
 
@@ -8886,16 +8849,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"super-regex@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "super-regex@npm:1.0.0"
-  dependencies:
-    function-timeout: "npm:^1.0.1"
-    time-span: "npm:^5.1.0"
-  checksum: 10c0/9727b57702308af74be90ed92d4612eed6c8b03fdf25efe1a3455e40d7145246516638bcabf3538e9e9c706d8ecb233e4888e0223283543fb2836d4d7acb6200
-  languageName: node
-  linkType: hard
-
 "superstruct@npm:^1.0.3":
   version: 1.0.4
   resolution: "superstruct@npm:1.0.4"
@@ -8912,7 +8865,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"supports-color@npm:^7.0.0, supports-color@npm:^7.1.0":
+"supports-color@npm:^7.0.0":
   version: 7.2.0
   resolution: "supports-color@npm:7.2.0"
   dependencies:
@@ -8928,7 +8881,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"supports-hyperlinks@npm:^3.1.0":
+"supports-hyperlinks@npm:^3.0.0":
   version: 3.2.0
   resolution: "supports-hyperlinks@npm:3.2.0"
   dependencies:
@@ -9021,6 +8974,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"text-extensions@npm:^2.0.0":
+  version: 2.4.0
+  resolution: "text-extensions@npm:2.4.0"
+  checksum: 10c0/6790e7ee72ad4d54f2e96c50a13e158bb57ce840dddc770e80960ed1550115c57bdc2cee45d5354d7b4f269636f5ca06aab4d6e0281556c841389aa837b23fcb
+  languageName: node
+  linkType: hard
+
 "text-hex@npm:1.0.x":
   version: 1.0.0
   resolution: "text-hex@npm:1.0.0"
@@ -9032,24 +8992,6 @@ __metadata:
   version: 0.2.0
   resolution: "text-table@npm:0.2.0"
   checksum: 10c0/02805740c12851ea5982686810702e2f14369a5f4c5c40a836821e3eefc65ffeec3131ba324692a37608294b0fd8c1e55a2dd571ffed4909822787668ddbee5c
-  languageName: node
-  linkType: hard
-
-"thenify-all@npm:^1.0.0":
-  version: 1.6.0
-  resolution: "thenify-all@npm:1.6.0"
-  dependencies:
-    thenify: "npm:>= 3.1.0 < 4"
-  checksum: 10c0/9b896a22735e8122754fe70f1d65f7ee691c1d70b1f116fda04fea103d0f9b356e3676cb789506e3909ae0486a79a476e4914b0f92472c2e093d206aed4b7d6b
-  languageName: node
-  linkType: hard
-
-"thenify@npm:>= 3.1.0 < 4":
-  version: 3.3.1
-  resolution: "thenify@npm:3.3.1"
-  dependencies:
-    any-promise: "npm:^1.0.0"
-  checksum: 10c0/f375aeb2b05c100a456a30bc3ed07ef03a39cbdefe02e0403fb714b8c7e57eeaad1a2f5c4ecfb9ce554ce3db9c2b024eba144843cd9e344566d9fcee73b04767
   languageName: node
   linkType: hard
 
@@ -9072,12 +9014,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"time-span@npm:^5.1.0":
-  version: 5.1.0
-  resolution: "time-span@npm:5.1.0"
-  dependencies:
-    convert-hrtime: "npm:^5.0.0"
-  checksum: 10c0/37b8284c53f4ee320377512ac19e3a034f2b025f5abd6959b8c1d0f69e0f06ab03681df209f2e452d30129e7b1f25bf573fb0f29d57e71f9b4a6b5b99f4c4b9e
+"through@npm:>=2.2.7 <3":
+  version: 2.3.8
+  resolution: "through@npm:2.3.8"
+  checksum: 10c0/4b09f3774099de0d4df26d95c5821a62faee32c7e96fb1f4ebd54a2d7c11c57fe88b0a0d49cf375de5fee5ae6bf4eb56dbbf29d07366864e2ee805349970d3cc
   languageName: node
   linkType: hard
 
@@ -9360,10 +9300,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"universal-user-agent@npm:^7.0.0, universal-user-agent@npm:^7.0.2":
-  version: 7.0.2
-  resolution: "universal-user-agent@npm:7.0.2"
-  checksum: 10c0/e60517ee929813e6b3ac0ceb3c66deccafadc71341edca160279ff046319c684fd7090a60d63aa61cd34a06c2d2acebeb8c2f8d364244ae7bf8ab788e20cd8c8
+"universal-user-agent@npm:^6.0.0":
+  version: 6.0.1
+  resolution: "universal-user-agent@npm:6.0.1"
+  checksum: 10c0/5c9c46ffe19a975e11e6443640ed4c9e0ce48fcc7203325757a8414ac49940ebb0f4667f2b1fa561489d1eb22cb2d05a0f7c82ec20c5cba42e58e188fb19b187
   languageName: node
   linkType: hard
 
@@ -10037,13 +9977,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yargs-parser@npm:^20.2.2":
-  version: 20.2.9
-  resolution: "yargs-parser@npm:20.2.9"
-  checksum: 10c0/0685a8e58bbfb57fab6aefe03c6da904a59769bd803a722bb098bd5b0f29d274a1357762c7258fb487512811b8063fb5d2824a3415a0a4540598335b3b086c72
-  languageName: node
-  linkType: hard
-
 "yargs-parser@npm:^21.1.1":
   version: 21.1.1
   resolution: "yargs-parser@npm:21.1.1"
@@ -10067,21 +10000,6 @@ __metadata:
     y18n: "npm:^4.0.0"
     yargs-parser: "npm:^18.1.2"
   checksum: 10c0/f1ca680c974333a5822732825cca7e95306c5a1e7750eb7b973ce6dc4f97a6b0a8837203c8b194f461969bfe1fb1176d1d423036635285f6010b392fa498ab2d
-  languageName: node
-  linkType: hard
-
-"yargs@npm:^16.0.0":
-  version: 16.2.0
-  resolution: "yargs@npm:16.2.0"
-  dependencies:
-    cliui: "npm:^7.0.2"
-    escalade: "npm:^3.1.1"
-    get-caller-file: "npm:^2.0.5"
-    require-directory: "npm:^2.1.1"
-    string-width: "npm:^4.2.0"
-    y18n: "npm:^5.0.5"
-    yargs-parser: "npm:^20.2.2"
-  checksum: 10c0/b1dbfefa679848442454b60053a6c95d62f2d2e21dd28def92b647587f415969173c6e99a0f3bab4f1b67ee8283bf735ebe3544013f09491186ba9e8a9a2b651
   languageName: node
   linkType: hard
 

--- a/gasp-node/rollup/runtime/src/lib.rs
+++ b/gasp-node/rollup/runtime/src/lib.rs
@@ -167,7 +167,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	//   `spec_version`, and `authoring_version` are the same between Wasm and native.
 	// This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
 	//   the compatible custom types.
-	spec_version: 107,
+	spec_version: 108,
 	impl_version: 3,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 3,

--- a/stash/api/_Stash.postman_collection.json
+++ b/stash/api/_Stash.postman_collection.json
@@ -553,12 +553,12 @@
 			"response": []
 		},
 		{
-			"name": "Tx Status by txHash or Entity ID",
+			"name": "Find transaction by txHash or Entity ID",
 			"request": {
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "{{baseUrl}}/tracing/type/{{type}}/tx/01J826JEJD3T2QB3DBV27XQ59C",
+					"raw": "{{baseUrl}}/tracing/type/{{type}}/tx/01JHMP5QT1YCEFJD3D7P38HJKD",
 					"host": [
 						"{{baseUrl}}"
 					],
@@ -567,7 +567,7 @@
 						"type",
 						"{{type}}",
 						"tx",
-						"01J826JEJD3T2QB3DBV27XQ59C"
+						"01JHMP5QT1YCEFJD3D7P38HJKD"
 					]
 				}
 			},
@@ -601,7 +601,7 @@
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "{{baseUrl}}/tracing/type/{{type}}/tx/listByAddress/0xf525b86742d20ca26069d39c0c5cbc7fcd6148ed/PROCESSED",
+					"raw": "{{baseUrl}}/tracing/type/{{type}}/tx/listByAddress/0x928f1040adb982d3ab32a62dc8eda57e9b81b4dd/PendingOnL2",
 					"host": [
 						"{{baseUrl}}"
 					],
@@ -611,37 +611,8 @@
 						"{{type}}",
 						"tx",
 						"listByAddress",
-						"0xf525b86742d20ca26069d39c0c5cbc7fcd6148ed",
-						"PROCESSED"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "Tx by Entity ID",
-			"request": {
-				"method": "GET",
-				"header": [],
-				"url": {
-					"raw": "{{baseUrl}}/tracing/type/{{type}}/tx/findByEntityId/01J826JEJD3T2QB3DBV27XQ59C",
-					"host": [
-						"{{baseUrl}}"
-					],
-					"path": [
-						"tracing",
-						"type",
-						"{{type}}",
-						"tx",
-						"findByEntityId",
-						"01J826JEJD3T2QB3DBV27XQ59C"
-					],
-					"query": [
-						{
-							"key": "",
-							"value": null,
-							"disabled": true
-						}
+						"0x928f1040adb982d3ab32a62dc8eda57e9b81b4dd",
+						"PendingOnL2"
 					]
 				}
 			},
@@ -661,6 +632,44 @@
 						"account",
 						"{{wallet}}",
 						"dashboard"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Token price",
+			"request": {
+				"method": "GET",
+				"header": []
+			},
+			"response": []
+		},
+		{
+			"name": "Store key value",
+			"request": {
+				"auth": {
+					"type": "noauth"
+				},
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n  \"key\": \"withdrawal\",\n  \"value\": \"0x2dfcf2fbb42084d0eb9b9e75f333ae900192ba941a898e9634dd93cdca76843e\"\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{baseUrl}}/key-value/store",
+					"host": [
+						"{{baseUrl}}"
+					],
+					"path": [
+						"key-value",
+						"store"
 					]
 				}
 			},

--- a/stash/src/app.ts
+++ b/stash/src/app.ts
@@ -18,6 +18,7 @@ import * as tracingController from './controller/TracingController.js'
 import * as tradingController from './controller/TradingController.js'
 import * as airdropController from './controller/mgxAirdropController.js'
 import * as tokenPriceController from './controller/TokenPriceController.js'
+import * as keyValueController from './controller/KeyValueController.js'
 
 import { createRequire } from 'module'
 const require = createRequire(import.meta.url)
@@ -128,6 +129,9 @@ app.post('/mgx-airdrop/link-address', airdropController.linkAddress)
 
 // Coinmarketcap listing endpoints
 app.get('/coinmarketcap/v1/summary', coinmarketcapController.summary)
+
+//key value storage endpoints
+app.post('/key-value/store', keyValueController.store)
 
 app.use('/doc', swaggerUI.serve, swaggerUI.setup(swaggerFile))
 

--- a/stash/src/controller/KeyValueController.ts
+++ b/stash/src/controller/KeyValueController.ts
@@ -1,0 +1,15 @@
+import { Request, Response } from 'express'
+import * as errorHandler from '../error/Handler.js'
+import * as keyValueService from '../service/KeyValueService.js'
+import { keyValueSchema } from '../schema/KeyValueSchema.js'
+
+export const store = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const { key, value } = req.body
+    keyValueSchema.validateSync({ key, value })
+    const stored = await keyValueService.store(key, value)
+    res.json({ stored: stored })
+  } catch (e) {
+    await errorHandler.handle(res, e)
+  }
+}

--- a/stash/src/controller/TracingController.ts
+++ b/stash/src/controller/TracingController.ts
@@ -128,8 +128,8 @@ export const getAllTransactionsByAddress = async (
 ): Promise<void> => {
   /*
    #swagger.tags = ['Tracing']
-   #swagger.summary = 'Get all transactions by address.'
-   #swagger.description = "Get all transactions by providing a specific address and type of a transaction."
+   #swagger.summary = 'Get all frontend created transactions by address.'
+   #swagger.description = "Get all frontend created transactions by providing a specific address and type of a transaction."
    #swagger.parameters['address'] = {
      in: 'path',
      description: 'Address to get transactions for',

--- a/stash/src/schema/KeyValueSchema.ts
+++ b/stash/src/schema/KeyValueSchema.ts
@@ -1,0 +1,6 @@
+import * as yup from 'yup'
+
+export const keyValueSchema = yup.object().shape({
+  key: yup.string().required('key is required'),
+  value: yup.string().required('value is required'),
+})

--- a/stash/src/schema/TracingSchema.ts
+++ b/stash/src/schema/TracingSchema.ts
@@ -9,7 +9,10 @@ export const startTracingSchema = yup.object().shape({
     .string()
     .required('address is required')
     .matches(/^0x/, 'address must begin with 0x'),
-  type: yup.string().required('type is required'),
+  type: yup
+    .string()
+    .required('type is required')
+    .oneOf(['deposit'], 'type must be "deposit"'),
   chain: yup
     .string()
     .required('chain is required')

--- a/stash/src/scraper/WithdrawalScraper.ts
+++ b/stash/src/scraper/WithdrawalScraper.ts
@@ -4,6 +4,8 @@ import { withdrawalRepository } from '../repository/TransactionRepository.js'
 import { ApiPromise } from '@polkadot/api'
 import { redis } from '../connector/RedisConnector.js'
 import logger from '../util/Logger.js'
+import { AnyTuple } from '@polkadot/types-codec/types'
+import { GenericExtrinsic } from '@polkadot/types'
 
 const NETWORK_LIST_KEY = 'affirmed_networks_list'
 const WITHDRAWAL_PENDING_ON_L2 = 'PendingOnL2'
@@ -20,6 +22,29 @@ export enum CreatedBy {
   Other = 'other',
 }
 
+export async function extractExtrinsicHashAndAnAddressFromBlock(
+  api: ApiPromise,
+  phaseApplyExtrinsic: number,
+  block: Block
+) {
+  let extrinsicHash, address
+  try {
+    const blockHash = await api.rpc.chain.getBlockHash(block.number)
+    const blockHeader = await api.rpc.chain.getHeader(blockHash)
+    const extinsics: GenericExtrinsic<AnyTuple>[] = (
+      await api.rpc.chain.getBlock(blockHeader.hash)
+    ).block.extrinsics
+    let extrinsic = extinsics[phaseApplyExtrinsic]
+    extrinsicHash = extrinsic.hash.toString()
+    address = extrinsic.signer.toString()
+    console.log('Extrinsic Hash:', extrinsicHash, 'Address:', address)
+    return { extrinsicHash, address }
+  } catch (error) {
+    logger.error('Error extracting extrinsic hash and address:', error)
+    return { extrinsicHash: '', address: '' }
+  }
+}
+
 export const processWithdrawalEvents = async (
   api: ApiPromise,
   block: Block
@@ -27,62 +52,56 @@ export const processWithdrawalEvents = async (
   const events = _.chain(block.events)
     .filter((ev) => filterEvents(ev[1]))
     .groupBy(([idx, _]) => idx)
-    .map((evs, _) => evs.map(([_, ev]) => ev))
+    .map((evs, idx) =>
+      evs.map(([phaseApplyExtrinsic, ev]) => ({ phaseApplyExtrinsic, ev }))
+    )
     .value()
   if (events.length > 0) {
     for (const eventGroup of events) {
       for (const event of eventGroup) {
-        if (event.method === 'WithdrawalRequestCreated') {
-          const existingWithdrawal = await withdrawalRepository
-            .search()
-            .where('txHash')
-            .equals((event.data as any).hash_)
-            .and('type')
-            .equals('withdrawal')
-            .returnFirst()
-
-          if (existingWithdrawal) {
-            await updateWithdrawal(api, existingWithdrawal, event.data)
-          } else {
-            const withdrawalData = await startTracingWithdrawal(api, event.data)
+        if (event.ev.method === 'WithdrawalRequestCreated') {
+          try {
+            const existingWithdrawal = await withdrawalRepository
+              .search()
+              .where('requestId')
+              .equals(
+                Number(String((event.ev.data as any).requestId.id).replace(/,/g, ''))
+              )
+              .and('chain')
+              .equals((event.ev.data as any).chain)
+              .and('txHash')
+              .equals((event.ev.data as any).hash_)
+              .returnFirst()
+            if (existingWithdrawal) {
+              logger.info(
+                'Existing withdrawal found, skipping the WithdrawalRequestCreated data: ',
+                existingWithdrawal
+              )
+              continue
+            }
+            const withdrawalData = await startTracingWithdrawal(
+              api,
+              event.ev.data,
+              event.phaseApplyExtrinsic,
+              block
+            )
             logger.info('Tracing started for withdrawal', withdrawalData)
+          } catch (error) {
+            logger.error('Error tracing withdrawal:', error)
           }
-        } else if (event.method === 'TxBatchCreated') {
-          await updateWithdrawalsWhenBatchCreated(api, event.data)
+        } else if (event.ev.method === 'TxBatchCreated') {
+          await updateWithdrawalsWhenBatchCreated(api, event.ev.data)
         }
       }
     }
   }
 }
 
-export const updateWithdrawal = async (
-  api: ApiPromise,
-  existingWithdrawal: any,
-  eventData: any
-) => {
-  existingWithdrawal.requestId = Number(
-    String(eventData.requestId.id).replace(/,/g, '')
-  )
-  existingWithdrawal.updated = Date.parse(new Date().toISOString())
-  existingWithdrawal.status = WITHDRAWAL_PENDING_ON_L2
-  existingWithdrawal.recipient = eventData.recipient
-  existingWithdrawal.proof = ''
-  const calldata = await api.rpc.rolldown.get_abi_encoded_l2_request(
-    eventData.chain,
-    eventData.requestId.id.replace(/,/g, '')
-  )
-  existingWithdrawal.calldata = calldata.toHex()
-  existingWithdrawal.closedBy = null
-  await withdrawalRepository.save(existingWithdrawal)
-  logger.info(
-    'Existing withdrawal updated with event WithdrawalRequestCreated',
-    existingWithdrawal
-  )
-}
-
 export const startTracingWithdrawal = async (
   api: ApiPromise,
-  eventData: any
+  eventData: any,
+  phaseApplyExtrinsic: number,
+  block: Block
 ): Promise<object> => {
   const timestamp = new Date().toISOString()
   const calldata = await api.rpc.rolldown.get_abi_encoded_l2_request(
@@ -94,22 +113,32 @@ export const startTracingWithdrawal = async (
   const network = networks.find((net: Network) => net.key === eventData.chain)
   const chainId = network ? network.chainId : 'unknown'
 
+  const { extrinsicHash, address } =
+    await extractExtrinsicHashAndAnAddressFromBlock(
+      api,
+      phaseApplyExtrinsic,
+      block
+    )
+  const redisKey = `withdrawal:${extrinsicHash}`
+  const keyExists = await redis.client.exists(redisKey)
+  console.log('Key Exists:', keyExists)
+
   const withdrawalData = {
-    requestId: Number(eventData.requestId.id.replace(/,/g, '')),
+    requestId: Number(String(eventData.requestId.id).replace(/,/g, '')),
     txHash: eventData.hash_,
-    address: '', // address (sender) we get from FE when they trigger start tracing, empty when withdrawal is started tracing by other means or until FE updates it
+    address: address,
     recipient: eventData.recipient,
     created: Date.parse(timestamp),
     updated: Date.parse(timestamp),
     status: WITHDRAWAL_PENDING_ON_L2,
     type: type,
     chain: eventData.chain,
-    amount: eventData.amount.replace(/,/g, ''),
+    amount: String(eventData.amount).replace(/,/g, ''),
     asset_chainId: chainId,
     asset_address: eventData.tokenAddress,
     proof: '',
     calldata: calldata.toHex(),
-    createdBy: CreatedBy.Other,
+    createdBy: keyExists ? CreatedBy.Frontend : CreatedBy.Other,
     closedBy: null,
   }
   return withdrawalRepository.save(withdrawalData)

--- a/stash/src/service/KeyValueService.ts
+++ b/stash/src/service/KeyValueService.ts
@@ -1,0 +1,11 @@
+import { redis } from '../connector/RedisConnector.js'
+
+export const store = async (
+  key: string,
+  value: string
+): Promise<{ value: string; timestamp: number }> => {
+  const now = new Date().toISOString()
+  const parsed = Date.parse(now)
+  await redis.client.hset(`${key}:${value}`, 'timestamp', parsed)
+  return { value: `${key}:${value}`, timestamp: parsed }
+}

--- a/stash/src/service/TracingService.ts
+++ b/stash/src/service/TracingService.ts
@@ -40,13 +40,6 @@ export const startTracingTransaction = async (
       logger.error(`Error in startTracingDeposit: ${error.message}`)
       throw error
     }
-  } else if (type === 'withdrawal') {
-    try {
-      return await processWithdrawalRequest(traceRequest)
-    } catch (error) {
-      logger.error(`Error in processWithdrawalRequest: ${error.message}`)
-      throw error
-    }
   } else {
     status = 'UNKNOWN'
   }
@@ -118,82 +111,13 @@ async function startTracingDeposit({
   }
 }
 
-async function processWithdrawalRequest({
-  txHash,
-  address,
-  type,
-  chain,
-  amount,
-  asset_chainId,
-  asset_address,
-}: TraceTransactionRequest) {
-  //check if it already exists
-  const existingWithdrawal = await withdrawalRepository
-    .search()
-    .where('txHash')
-    .equals(txHash)
-    .and('type')
-    .equals(type)
-    .returnFirst()
-  if (existingWithdrawal) {
-    existingWithdrawal.createdBy = CreatedBy.Frontend
-    existingWithdrawal.address = address
-    const timestamp = new Date().toISOString()
-    existingWithdrawal.updated = Date.parse(timestamp)
-    await withdrawalRepository.save(existingWithdrawal)
-    logger.info({
-      message: 'Withdrawal updated with createdBy and an address (sender):',
-      transaction: existingWithdrawal,
-    })
-    return {
-      ...existingWithdrawal,
-    }
-  } else {
-    //create a new one
-    const timestamp = new Date().toISOString()
-    const affirmedNetworks = await redis.client.get(NETWORK_LIST_KEY)
-    const networks = affirmedNetworks ? JSON.parse(affirmedNetworks) : []
-    const network = networks.find((net: Network) => net.key === chain)
-    const chainId = network ? network.chainId : 'unknown'
-
-    const withdrawalData = {
-      requestId: null,
-      txHash: txHash,
-      address: address,
-      recipient: '', //recipient we get from WithdrawalRequestCreated, empty when we FE starts tracing
-      created: Date.parse(timestamp),
-      updated: Date.parse(timestamp),
-      status: WITHDRAWAL_INITIATED_BY_FE,
-      type: type,
-      chain: chain,
-      amount: amount.replace(/,/g, ''),
-      asset_chainId: chainId,
-      asset_address: asset_address,
-      proof: '',
-      calldata: '',
-      createdBy: CreatedBy.Frontend,
-      closedBy: null,
-    }
-    const withdrawal = await withdrawalRepository.save(withdrawalData)
-    const symbols = Object.getOwnPropertySymbols(withdrawal)
-    const entityIdSymbol = symbols.find(
-      (symbol) => symbol.toString() === 'Symbol(entityId)'
-    )
-    const value = withdrawal[entityIdSymbol as any]
-    return {
-      ...withdrawal,
-      entityId: value,
-    }
-  }
-}
-
 export const getTransactionsByAddress = async (
   address: string,
   type: string
 ): Promise<object[]> => {
   const repository =
     type === 'deposit' ? depositRepository : withdrawalRepository
-  return await repository.search().where('address').equals(address).return.all()
+  return await repository.search().where('address').equals(address).and('createdBy').equals(CreatedBy.Frontend).all()
 }
 
 export const getByTxHashOrEntityId = async (

--- a/stash/swagger-output.json
+++ b/stash/swagger-output.json
@@ -1014,8 +1014,8 @@
         "tags": [
           "Tracing"
         ],
-        "summary": "Get all transactions by address.",
-        "description": "Get all transactions by providing a specific address and type of a transaction.",
+        "summary": "Get all frontend created transactions by address.",
+        "description": "Get all frontend created transactions by providing a specific address and type of a transaction.",
         "parameters": [
           {
             "name": "type",
@@ -1307,6 +1307,33 @@
                 }
               }
             }
+          }
+        }
+      }
+    },
+    "/key-value/store": {
+      "post": {
+        "description": "",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "key": {
+                  "example": "any"
+                },
+                "value": {
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
           }
         }
       }

--- a/stash/test/key.value.unit.test.ts
+++ b/stash/test/key.value.unit.test.ts
@@ -1,0 +1,23 @@
+import { store } from '../src/service/KeyValueService.js';
+  import { vi, describe, beforeEach, afterEach, it, expect } from 'vitest';
+import { redis } from '../src/connector/RedisConnector.js';
+
+  describe('store', () => {
+    beforeEach(() => {
+      vi.spyOn(redis.client, 'hset').mockResolvedValue(1);
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('should store the key-value pair with a timestamp', async () => {
+      const key = 'testKey';
+      const value = 'testValue';
+      const result = await store(key, value);
+
+      expect(result.value).toBe(`${key}:${value}`);
+      expect(typeof result.timestamp).toBe('number');
+      expect(redis.client.hset).toHaveBeenCalledWith(`${key}:${value}`, 'timestamp', result.timestamp);
+    });
+  });


### PR DESCRIPTION
- **revert version change**
- **Monad & MegaEth integration**
- **add deployment configs for monad & megaeth**
- **persist monad addresses**
- **bump version to 108**
- **revert changes from local testing**
- **GASP-2120: Monad/MegaEth integration upgrade TaskManager contract (#540)**
- **enum -> uint8**
- **chore:GASP-2075-2076: start tracing withdrawals with extrinsic hash**
- **feat: GASP-2075-2076: find extrinsic based on index in the event**
- **chore: GASP-2075-2076: if existing skip + handle error in block**
- **chore: GASP-2075-2076: fix validator for start tracing**
- **chore: GASP-2075-2076: add tests for key value storage**
- **chore: GASP-2075-2076: fix withdrawal scraper tests+cleanup+add new tests**
- **chore: GASP-2075-2076: add key value call to collection**
- **fix: update the image references used in e2e tests for gasp-avs and gasp-node services to use the correct reference when running tests (#535)**
- **ci: add docker compose logs output as a separate step and also upload an artifact on e2e tests job failure (#536)**
- **chore: update concurrency group in branch-main.yml for improved workflow isolation (#542)**
- **feat: change storage type**
- **feat: persist deployment output**
- **chore(ci): update semantic-release configuration to correctly set docker image version in release notes (#545)**
