### PR TITLE
feat: sequencer, node - fix seq stale update

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,8 +1,6 @@
 name: rollup
 
 include:
-  - path: ./contracts/compose.anvil-stubs.yml # anvil stubs
-  # - path: ./contracts/compose.reth-stubs.yml # reth stubs
   - path: ./avs-aggregator/compose.yml
   - path: ./gasp-avs/compose.yml
   - path: ./gasp-node/compose.yml

--- a/contracts/Dockerfile
+++ b/contracts/Dockerfile
@@ -1,10 +1,9 @@
-FROM ghcr.io/foundry-rs/foundry:nightly-c2e529786c07ee7069cefcd4fe2db41f0e46cef6
+FROM ghcr.io/foundry-rs/foundry:v1.0.0
 
-# Copy our source code into the container
 WORKDIR /app
 
-# Build the source code
-COPY . .
+COPY --chown=foundry:foundry . .
 RUN forge build
+# RUN forge test
 
 ENTRYPOINT ["forge"]

--- a/contracts/compose.yml
+++ b/contracts/compose.yml
@@ -1,8 +1,11 @@
+include:
+  - path: ./compose.anvil-stubs.yml
+  # - path: ./compose.reth-stubs.yml
+
 services:
   eth-contracts-deployment:
     build: .
     image: gaspxyz/gasp-contracts:${GASP_CONTRACTS_VERSION:-local}
-    platform: linux/amd64
     depends_on:
       eth-stub:
         condition: service_healthy
@@ -27,7 +30,6 @@ services:
   arbitrum-contracts-deployment:
     build: .
     image: gaspxyz/gasp-contracts:${GASP_CONTRACTS_VERSION:-localarb}
-    platform: linux/amd64
     depends_on:
       arbitrum-stub:
         condition: service_healthy
@@ -46,7 +48,6 @@ services:
   base-contracts-deployment:
     build: .
     image: gaspxyz/gasp-contracts:${GASP_CONTRACTS_VERSION:-localbase}
-    platform: linux/amd64
     depends_on:
       base-stub:
         condition: service_healthy

--- a/gasp-node/pallets/rolldown/src/lib.rs
+++ b/gasp-node/pallets/rolldown/src/lib.rs
@@ -1494,7 +1494,7 @@ impl<T: Config> Pallet<T> {
 		ensure!(lowest_id > 0u128, Error::<T>::WrongRequestId);
 
 		ensure!(
-			lowest_id <= LastProcessedRequestOnL2::<T>::get(l1) + 1,
+			lowest_id <= MaxAcceptedRequestIdOnl2::<T>::get(l1) + 1,
 			Error::<T>::WrongRequestId
 		);
 
@@ -1502,7 +1502,7 @@ impl<T: Config> Pallet<T> {
 			(update.pendingDeposits.len() as u128) +
 			(update.pendingCancelResolutions.len() as u128);
 
-		ensure!(last_id >= LastProcessedRequestOnL2::<T>::get(l1), Error::<T>::WrongRequestId);
+		ensure!(last_id > MaxAcceptedRequestIdOnl2::<T>::get(l1), Error::<T>::WrongRequestId);
 
 		let mut deposit_it = update.pendingDeposits.iter();
 		let mut cancel_it = update.pendingCancelResolutions.iter();

--- a/sequencer/l2api/src/l2.rs
+++ b/sequencer/l2api/src/l2.rs
@@ -261,6 +261,25 @@ impl L2Interface for Gasp {
     }
 
     #[tracing::instrument(level = "trace", skip(self), ret)]
+    async fn get_latest_accepted_request_id(
+        &self,
+        chain: gasp_types::Chain,
+        at: HashOf<GaspConfig>,
+    ) -> Result<u128, L2Error> {
+        let chain: crate::types::subxt::Chain = chain.into();
+        let storage = gasp_bindings::api::storage()
+            .rolldown()
+            .max_accepted_request_id_onl2(chain);
+        Ok(self
+            .client
+            .storage()
+            .at(at)
+            .fetch(&storage)
+            .await?
+            .unwrap_or_default())
+    }
+
+    #[tracing::instrument(level = "trace", skip(self), ret)]
     async fn get_read_rights(
         &self,
         chain: gasp_types::Chain,

--- a/sequencer/l2api/src/lib.rs
+++ b/sequencer/l2api/src/lib.rs
@@ -101,11 +101,8 @@ pub trait L2Interface {
         at: H256,
     ) -> Result<u128, L2Error>;
 
-    async fn get_latest_accepted_request_id(
-        &self,
-        chain: Chain,
-        at: H256,
-    ) -> Result<u128, L2Error>;
+    async fn get_latest_accepted_request_id(&self, chain: Chain, at: H256)
+        -> Result<u128, L2Error>;
 
     async fn get_read_rights(&self, chain: Chain, at: H256) -> Result<u128, L2Error>;
 

--- a/sequencer/l2api/src/lib.rs
+++ b/sequencer/l2api/src/lib.rs
@@ -101,6 +101,12 @@ pub trait L2Interface {
         at: H256,
     ) -> Result<u128, L2Error>;
 
+    async fn get_latest_accepted_request_id(
+        &self,
+        chain: Chain,
+        at: H256,
+    ) -> Result<u128, L2Error>;
+
     async fn get_read_rights(&self, chain: Chain, at: H256) -> Result<u128, L2Error>;
 
     async fn get_selected_sequencer(

--- a/sequencer/l2api/src/mock.rs
+++ b/sequencer/l2api/src/mock.rs
@@ -44,7 +44,7 @@ impl crate::L2Interface for L2{
         chain: Chain,
         at: H256,
     ) -> Result<u128, L2Error>;
-    
+
     async fn get_read_rights(&self, chain: Chain, at: H256) -> Result<u128, L2Error>;
     async fn get_selected_sequencer(
         &self,

--- a/sequencer/l2api/src/mock.rs
+++ b/sequencer/l2api/src/mock.rs
@@ -38,6 +38,13 @@ impl crate::L2Interface for L2{
         at: H256,
     ) -> Result<u128, L2Error>;
 
+    // TODO: maybe rename
+    async fn get_latest_accepted_request_id(
+        &self,
+        chain: Chain,
+        at: H256,
+    ) -> Result<u128, L2Error>;
+    
     async fn get_read_rights(&self, chain: Chain, at: H256) -> Result<u128, L2Error>;
     async fn get_selected_sequencer(
         &self,

--- a/sequencer/sequencer/src/sequencer.rs
+++ b/sequencer/sequencer/src/sequencer.rs
@@ -444,21 +444,21 @@ where
         &self,
         at: H256,
     ) -> Result<Option<(H256, gasp_types::L1Update)>, Error> {
-        let latest_processed_on_l2 = self
+        let latest_accepted_on_l2 = self
             .l2
-            .get_latest_processed_request_id(self.chain, at)
+            .get_latest_accepted_request_id(self.chain, at)
             .await?;
         let latest_request_l1 = self.l1.get_latest_reqeust_id().await?;
 
         tracing::debug!(
-            "latest available on L1: {:?} latest processed on L2 {}",
+            "latest available on L1: {:?} latest accepted on L2 {}",
             latest_request_l1,
-            latest_processed_on_l2
+            latest_accepted_on_l2
         );
 
         match latest_request_l1 {
-            Some(latest_request_l1) if latest_request_l1 > latest_processed_on_l2 => {
-                let start = latest_processed_on_l2.saturating_add(1u128);
+            Some(latest_request_l1) if latest_request_l1 > latest_accepted_on_l2 => {
+                let start = latest_accepted_on_l2.saturating_add(1u128);
                 let end = std::cmp::min(latest_request_l1, start.saturating_add(self.limit));
                 tracing::info!("new requests availabla, fetching range {}..{}", start, end);
 


### PR DESCRIPTION
Both sequencer and node are modded to use MaxAcceptedRequestIdOnl2 instead of LastProcessedRequestOnL2 for updates
Also, contains one cmp change in node rolldown

Jira ticket: https://mangatafinance.atlassian.net/browse/GASP-2115