### PR TITLE
chore: post multiswap mods release alignment

### DIFF
--- a/gasp-node/Cargo.lock
+++ b/gasp-node/Cargo.lock
@@ -5974,6 +5974,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
+ "sp-stable-swap",
  "sp-std",
  "test-case",
 ]
@@ -6202,6 +6203,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
+ "sp-stable-swap",
  "sp-std",
  "test-case",
 ]
@@ -10216,6 +10218,14 @@ dependencies = [
  "sp-keystore",
  "sp-runtime",
  "sp-staking",
+ "sp-std",
+]
+
+[[package]]
+name = "sp-stable-swap"
+version = "1.0.0"
+dependencies = [
+ "sp-runtime",
  "sp-std",
 ]
 

--- a/gasp-node/Cargo.toml
+++ b/gasp-node/Cargo.toml
@@ -18,6 +18,7 @@ codegen-units = 1
 [workspace]
 resolver = "2"
 members = [
+	'primitives/*',
 	'pallets/*',
 	'rpc/nonce',
 	'rollup/node',
@@ -26,6 +27,8 @@ members = [
 ]
 
 [workspace.dependencies]
+sp-stable-swap = { path = "./primitives/stable-swap", default-features = false }
+
 alloy-primitives = { version = "0.5.0", default-features = false }
 alloy-sol-types = { version = "0.5.0", default-features = false }
 aquamarine = "0.1.12"

--- a/gasp-node/pallets/market/Cargo.toml
+++ b/gasp-node/pallets/market/Cargo.toml
@@ -27,6 +27,7 @@ sp-core = { workspace = true, default-features = false }
 sp-io = { workspace = true, default-features = false }
 sp-runtime = { workspace = true, default-features = false }
 sp-std = { workspace = true, default-features = false }
+sp-stable-swap = { workspace = true, default-features = false }
 
 orml-traits = { workspace = true, default-features = false }
 orml-tokens = { workspace = true, default-features = false }
@@ -58,6 +59,7 @@ std = [
 	"sp-io/std",
 	"sp-runtime/std",
 	"sp-std/std",
+	"sp-stable-swap/std",
 	"orml-traits/std",
 	"orml-tokens/std",
 	"pallet-fee-lock/std"

--- a/gasp-node/pallets/market/src/lib.rs
+++ b/gasp-node/pallets/market/src/lib.rs
@@ -45,6 +45,7 @@ use sp_std::{
 
 use orml_tokens::MultiTokenCurrencyExtended;
 use orml_traits::asset_registry::Inspect as AssetRegistryInspect;
+use sp_stable_swap::UpdateValutaion;
 
 pub mod weights;
 pub use crate::weights::WeightInfo;
@@ -185,6 +186,7 @@ pub mod pallet {
 		/// StableSwap pools
 		type StableSwap: Mutate<Self::AccountId, CurrencyId = Self::CurrencyId, Balance = Self::Balance>
 			+ ComputeBalances
+			+ sp_stable_swap::UpdateValutaion<Self::CurrencyId>
 			+ ValuateXyk<Self::Balance, Self::CurrencyId>;
 
 		/// Reward apis for native asset LP tokens activation
@@ -1182,6 +1184,19 @@ pub mod pallet {
 
 			Ok(().into())
 		}
+
+		#[pallet::call_index(8)]
+		#[pallet::weight((Weight::from_parts(25_000_000, 0))
+			.saturating_add(T::DbWeight::get().writes(5 as u64))
+    )]
+		pub fn stable_swap_update_eq_assets(
+			origin: OriginFor<T>,
+			asset_id: T::CurrencyId,
+			eq_assets_update: Vec<(T::CurrencyId, bool)>,
+		) -> DispatchResult {
+			T::StableSwap::update_eq_assets(asset_id, eq_assets_update)?;
+			Ok(().into())
+		}
 	}
 
 	impl<T: Config> Pallet<T> {
@@ -1231,6 +1246,10 @@ pub mod pallet {
 					Some(b) => Some(b),
 					None => T::FeeLock::is_swap_tokens_lockless(id, amount_out).then_some(true),
 				};
+			}
+
+			if swap_pool_list.len() == 1 && !T::FeeLock::is_whitelisted(asset_id_in) {
+				is_lockless = Some(false)
 			}
 
 			// We counldn't find a reason to make it lockless so it will be fee_lock

--- a/gasp-node/pallets/stable-swap/Cargo.toml
+++ b/gasp-node/pallets/stable-swap/Cargo.toml
@@ -29,6 +29,7 @@ sp-core = { workspace = true, default-features = false }
 sp-io = { workspace = true, default-features = false }
 sp-runtime = { workspace = true, default-features = false }
 sp-std = { workspace = true, default-features = false }
+sp-stable-swap = { workspace = true, default-features = false }
 
 orml-traits = { workspace = true, default-features = false }
 orml-tokens = { workspace = true, default-features = false }
@@ -51,6 +52,7 @@ std = [
 	"scale-info/std",
 	"sp-arithmetic/std",
 	"sp-core/std",
+	"sp-stable-swap/std",
 	"sp-io/std",
 	"sp-runtime/std",
 	"sp-std/std",

--- a/gasp-node/pallets/stable-swap/src/lib.rs
+++ b/gasp-node/pallets/stable-swap/src/lib.rs
@@ -572,7 +572,31 @@ pub mod pallet {
 			eq_assets_update: Vec<(T::CurrencyId, bool)>,
 		) -> DispatchResult {
 			let _ = ensure_root(origin)?;
+			Self::do_update_eq_assets(asset_id, eq_assets_update)?;
+			Ok(().into())
+		}
+	}
 
+	impl<T: Config> sp_stable_swap::UpdateValutaion<T::CurrencyId> for Pallet<T> {
+		fn update_eq_assets(
+			asset_id: T::CurrencyId,
+			eq_assets_update: Vec<(T::CurrencyId, bool)>,
+		) -> Result<(), DispatchError> {
+			Pallet::<T>::do_update_eq_assets(asset_id, eq_assets_update)?;
+			Ok(())
+		}
+	}
+
+	impl<T: Config> Pallet<T> {
+		pub const FEE_DENOMINATOR: u128 = 10_u128.pow(10);
+		pub(crate) const PRECISION_EXP: u32 = 18;
+		const PRECISION: u128 = 10_u128.pow(Self::PRECISION_EXP);
+		const A_PRECISION: u128 = 100;
+
+		pub fn do_update_eq_assets(
+			asset_id: T::CurrencyId,
+			eq_assets_update: Vec<(T::CurrencyId, bool)>,
+		) -> Result<(), Error<T>> {
 			let mut eq_assets = EqAssets::<T>::get(asset_id).unwrap_or_default();
 
 			for (eq_asset, is_eq) in eq_assets_update {
@@ -599,13 +623,6 @@ pub mod pallet {
 
 			Ok(())
 		}
-	}
-
-	impl<T: Config> Pallet<T> {
-		pub const FEE_DENOMINATOR: u128 = 10_u128.pow(10);
-		pub(crate) const PRECISION_EXP: u32 = 18;
-		const PRECISION: u128 = 10_u128.pow(Self::PRECISION_EXP);
-		const A_PRECISION: u128 = 100;
 
 		// calls impl
 		pub fn do_create_pool(

--- a/gasp-node/primitives/stable-swap/Cargo.toml
+++ b/gasp-node/primitives/stable-swap/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "sp-stable-swap"
+version = "1.0.0"
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+edition.workspace = true
+
+[dependencies]
+sp-runtime = { workspace = true, default-features = false }
+sp-std = { workspace = true, default-features = false }
+
+[features]
+default = ["std"]
+std = [
+	"sp-runtime/std",
+	"sp-std/std",
+]

--- a/gasp-node/primitives/stable-swap/src/lib.rs
+++ b/gasp-node/primitives/stable-swap/src/lib.rs
@@ -1,0 +1,10 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+use sp_runtime::DispatchResult;
+use sp_std::vec::Vec;
+
+pub trait UpdateValutaion<CurrencyId> {
+	fn update_eq_assets(
+		asset_id: CurrencyId,
+		eq_assets_update: Vec<(CurrencyId, bool)>,
+	) -> DispatchResult;
+}

--- a/gasp-node/rollup/runtime/integration-test/src/asset_registry.rs
+++ b/gasp-node/rollup/runtime/integration-test/src/asset_registry.rs
@@ -1,0 +1,117 @@
+use crate::setup::*;
+
+use frame_support::dispatch::{DispatchInfo, PostDispatchInfo};
+pub use frame_support::unsigned::TransactionValidityError;
+use orml_asset_registry::{IdToL1Asset, L1AssetToId};
+use pallet_market::PoolKind;
+use rollup_runtime::{
+	config::{
+		pallet_transaction_payment::{OnChargeHandler, ToAuthor},
+		BnbAccountIdOf, TreasuryAccountIdOf,
+	},
+	fees::FEE_PRECISION,
+	AssetMetadata, FeeLockTriggerTrait, L1Asset, OnChargeTransactionHandler,
+};
+use sp_runtime::transaction_validity::InvalidTransaction;
+
+const ASSET_ID_1: u32 = 1;
+const ASSET_ID_2: u32 = 2;
+const POOL_ID: u32 = 3;
+// runtime_config::fees::MarketTotalFee
+const FEE: u128 = UNIT * 30_000_000 / FEE_PRECISION;
+const TRSY_FEE_P: u128 = FEE * 3_333_333_334 / FEE_PRECISION;
+const BNB_FEE: u128 = TRSY_FEE_P * 5_000_000_000 / FEE_PRECISION;
+const TRSY_FEE: u128 = TRSY_FEE_P - BNB_FEE;
+const POOL_FEE: u128 = FEE - TRSY_FEE - BNB_FEE;
+const FEE_LOCK_PERIOD_LENGTH: u32 = 10;
+const FEE_LOCK_AMOUNT: u128 = 10 * UNIT;
+const NATIVE_ASSET_ID_ADDRESS: L1Asset = L1Asset::Ethereum([7u8; 20]);
+
+type Market = pallet_market::Pallet<Runtime>;
+
+fn test_env() -> TestExternalities {
+	ExtBuilder {
+		balances: vec![
+			(AccountId::from(ALICE), NATIVE_ASSET_ID, 1000 * UNIT),
+			(AccountId::from(ALICE), ASSET_ID_1, 100 * UNIT),
+			(AccountId::from(ALICE), ASSET_ID_2, 100 * UNIT),
+			(AccountId::from(BOB), ASSET_ID_2, 100 * UNIT),
+		],
+		assets: vec![(
+			NATIVE_ASSET_ID,
+			AssetMetadata {
+				decimals: 18,
+				name: BoundedVec::truncate_from("Dummy token".as_bytes().to_vec()),
+				symbol: BoundedVec::truncate_from("DUMMY".as_bytes().to_vec()),
+				existential_deposit: 0,
+				additional: CustomMetadata { xcm: None, xyk: None },
+			},
+			Some(NATIVE_ASSET_ID_ADDRESS),
+		)],
+		..ExtBuilder::default()
+	}
+	.build()
+}
+
+fn origin() -> RuntimeOrigin {
+	RuntimeOrigin::signed(AccountId::from(ALICE))
+}
+
+fn root() -> RuntimeOrigin {
+	frame_system::RawOrigin::Root.into()
+}
+
+fn init_fee_lock(amount: Balance) {
+	FeeLock::update_fee_lock_metadata(
+		root(),
+		Some(FEE_LOCK_PERIOD_LENGTH),
+		Some(amount),
+		Some(1),
+		Some(vec![]),
+	)
+	.unwrap();
+}
+
+pub(crate) fn events() -> Vec<RuntimeEvent> {
+	System::events()
+		.into_iter()
+		.map(|r| r.event)
+		.filter_map(|e| match e {
+			RuntimeEvent::FeeLock(_) |
+			RuntimeEvent::Tokens(_) |
+			RuntimeEvent::TransactionPayment(_) => Some(e),
+			_ => None,
+		})
+		.collect::<Vec<_>>()
+}
+
+#[test]
+fn register_l1_asset() {
+	test_env().execute_with(|| {
+		let metadata = AssetMetadataOf {
+			decimals: 18,
+			name: BoundedVec::truncate_from("Dummy token".as_bytes().to_vec()),
+			symbol: BoundedVec::truncate_from("DUMMY".as_bytes().to_vec()),
+			existential_deposit: 0,
+			additional: CustomMetadata { xcm: None, xyk: None },
+		};
+
+		assert_eq!(IdToL1Asset::<Runtime>::get(NATIVE_ASSET_ID), Some(NATIVE_ASSET_ID_ADDRESS));
+
+		assert_eq!(L1AssetToId::<Runtime>::get(NATIVE_ASSET_ID_ADDRESS), Some(NATIVE_ASSET_ID));
+
+		let updated_asset_id = L1Asset::Ethereum([8u8; 20]);
+		AssetRegistry::update_l1_asset_data(
+			root(),
+			NATIVE_ASSET_ID,
+			Some(updated_asset_id.clone()),
+		)
+		.unwrap();
+
+		assert_eq!(IdToL1Asset::<Runtime>::get(NATIVE_ASSET_ID), Some(updated_asset_id.clone()));
+
+		assert_eq!(L1AssetToId::<Runtime>::get(updated_asset_id), Some(NATIVE_ASSET_ID));
+
+		assert_eq!(L1AssetToId::<Runtime>::get(NATIVE_ASSET_ID_ADDRESS), None);
+	})
+}

--- a/gasp-node/rollup/runtime/integration-test/src/bootstrap.rs
+++ b/gasp-node/rollup/runtime/integration-test/src/bootstrap.rs
@@ -23,6 +23,7 @@ fn bootstrap_updates_metadata_and_creates_pool_correctly() {
 					..CustomMetadata::default()
 				},
 			},
+			None,
 		)],
 		..ExtBuilder::default()
 	}

--- a/gasp-node/rollup/runtime/integration-test/src/lib.rs
+++ b/gasp-node/rollup/runtime/integration-test/src/lib.rs
@@ -1,5 +1,6 @@
 #![cfg(test)]
 
+mod asset_registry;
 mod bootstrap;
 mod council;
 mod fee_lock;

--- a/gasp-node/rollup/runtime/integration-test/src/market.rs
+++ b/gasp-node/rollup/runtime/integration-test/src/market.rs
@@ -862,3 +862,55 @@ fn swap_is_pre_validated() {
 		assert_eq!(res.err().unwrap(), orml_tokens::Error::<Runtime>::BalanceTooLow.into());
 	})
 }
+
+#[test]
+// reproduces GASP-2211
+fn test_is_lockless_for_atomic_swap_that_is_not_whitelisted() {
+	test_env().execute_with(|| {
+		let bob = AccountId::from(BOB);
+
+		mint_token(NATIVE_ASSET_ID, &bob, DEFAULT_MINT_AMOUNT);
+		let token_id_1 = create_new_token(&bob, DEFAULT_MINT_AMOUNT);
+		let pool_id = token_id_1 + 1;
+
+		Market::create_pool(
+			RuntimeOrigin::signed(bob),
+			PoolKind::Xyk,
+			NATIVE_ASSET_ID,
+			100_000 * UNIT,
+			token_id_1,
+			100_000 * UNIT,
+		)
+		.unwrap();
+
+		FeeLock::update_fee_lock_metadata(
+			RuntimeOrigin::root(),
+			Some(50),
+			Some(50 * UNIT),
+			Some(100 * UNIT),
+			Some(vec![]),
+		)
+		.unwrap();
+		assert!(FeeLock::get_fee_lock_metadata().unwrap().whitelisted_tokens.is_empty());
+
+		let (sell_info, _) = Market::get_multiswap_sell_info(
+			vec![pool_id],
+			token_id_1,
+			1 * UNIT,
+			NATIVE_ASSET_ID,
+			2000 * UNIT,
+		)
+		.unwrap();
+		assert!(!sell_info.is_lockless);
+
+		let (sell_info, _) = Market::get_multiswap_sell_info(
+			vec![pool_id],
+			token_id_1,
+			150 * UNIT,
+			NATIVE_ASSET_ID,
+			2000 * UNIT,
+		)
+		.unwrap();
+		assert!(!sell_info.is_lockless);
+	})
+}

--- a/gasp-node/rollup/runtime/integration-test/src/setup.rs
+++ b/gasp-node/rollup/runtime/integration-test/src/setup.rs
@@ -6,10 +6,13 @@ pub use frame_support::{
 };
 pub use orml_traits::currency::{MultiCurrency, MultiCurrencyExtended};
 pub use rollup_runtime::Get;
+use rollup_runtime::L1Asset;
 pub use sp_io::TestExternalities;
 pub use sp_runtime::{codec::Encode, BoundedVec, BuildStorage, MultiAddress, Permill};
 
 pub use rollup_imports::*;
+
+use crate::asset_registry;
 
 mod rollup_imports {
 	pub use rollup_runtime::{
@@ -51,7 +54,7 @@ pub fn microcent(decimals: u32) -> Balance {
 }
 
 pub struct ExtBuilder {
-	pub assets: Vec<(TokenId, AssetMetadataOf)>,
+	pub assets: Vec<(TokenId, AssetMetadataOf, Option<L1Asset>)>,
 	pub balances: Vec<(AccountId, TokenId, Balance)>,
 }
 
@@ -62,7 +65,7 @@ impl Default for ExtBuilder {
 }
 
 impl ExtBuilder {
-	pub fn assets(mut self, assets: Vec<(TokenId, AssetMetadataOf)>) -> Self {
+	pub fn assets(mut self, assets: Vec<(TokenId, AssetMetadataOf, Option<L1Asset>)>) -> Self {
 		self.assets = assets;
 		self
 	}
@@ -88,12 +91,12 @@ impl ExtBuilder {
 			.assimilate_storage(&mut t)
 			.unwrap();
 
-		let encoded: Vec<(TokenId, Vec<u8>, Option<_>)> = self
+		let encoded: Vec<(TokenId, Vec<u8>, Option<L1Asset>)> = self
 			.assets
 			.iter()
-			.map(|(id, meta)| {
+			.map(|(id, meta, assset_id)| {
 				let encoded = AssetMetadataOf::encode(&meta);
-				(*id, encoded, None)
+				(*id, encoded, assset_id.clone())
 			})
 			.collect();
 

--- a/gasp-node/rollup/runtime/integration-test/src/xyk.rs
+++ b/gasp-node/rollup/runtime/integration-test/src/xyk.rs
@@ -17,6 +17,7 @@ fn test_env(xyk_metadata: Option<XykMetadata>) -> TestExternalities {
 				existential_deposit: Default::default(),
 				additional: CustomMetadata { xyk: xyk_metadata, ..CustomMetadata::default() },
 			},
+			None,
 		)],
 		..ExtBuilder::default()
 	}

--- a/gasp-node/rollup/runtime/src/lib.rs
+++ b/gasp-node/rollup/runtime/src/lib.rs
@@ -166,7 +166,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	//   `spec_version`, and `authoring_version` are the same between Wasm and native.
 	// This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
 	//   the compatible custom types.
-	spec_version: 108,
+	spec_version: 109,
 	impl_version: 3,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 3,


### PR DESCRIPTION
- **chore(ci): fix the release job missing yarn 4.7.0 dependency**
- **fix: use newer forge version**
- **fix: typo**
- **Revert "fix: use newer forge version"**
- **chore: update Dockerfile to use new Foundry image from internal gaspxyz Docker repo**
- **fix(stash): semantic-release dependencies**
- **feat: bump bindings**
- **correct bindings**
- **feat: add sp-stable-swap crate with UpdateValuation trait for stableswaps**
- **feat: make atomic non lockless when input token is not whitelisted**
- **ci: add missing submodules checkout in gasp-node runtime benchmarks test workflow (#585)**
- **test: add integration proving that token address can be changed by sudo**
- **test: allign test to multiswap mods**
- **ci: remove --depth 1 from git submodule update for better compatibility in workflows**
- **chore: gasp-2233 sonic prod use tenderly instead of alchemy (#590)**
- **feat: gasp-2232 use totalamountin in volume and tvl (#593)**
- **chore: gasp-2232 update sdk types**
- **chore: add empty configs + allow deploy to staging from any branch (#573)**
- **chore: add standard env to app yaml**
- **chore: add runtime config**
- **chore: add runtime config new**
- **chore: add runtime config standard**
- **chore: add runtime config flex**
- **chore: change to ubuntu 22**
- **chore: update sdk for coinmarketcap and tickers + update node to version 22**
- **chore: dont run faucet test for now**
- **chore: update yarn lock with new sdk types for stash**
- **chore: bump e2e test to commit from eth-rollup-develop branch**
- **chore: bump yarn deps**
- **chore: fix formatting**
